### PR TITLE
APIの修正

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -463,23 +463,10 @@ components:
           format: date-time
         applicant:
           $ref: "#/components/schemas/User"
+        current_detail:
+          $ref: "#/components/schemas/ApplicationLog"
         current_state:
           $ref: "#/components/schemas/StateEnum"
-        type:
-          $ref: "#/components/schemas/TypeEnum"
-        title:
-          type: string
-          example: "夏コミの交通費をお願いします。"
-        remarks:
-          type: string
-          example: "〇〇駅から〇〇駅への移動"
-        paid_at:
-          type: string
-          format: date
-        ammount:
-          type: integer
-          minimum: 1
-          example: 1200
     DetailedApplication:
       allOf:
         - $ref: "#/components/schemas/CompactApplication"
@@ -573,9 +560,6 @@ components:
         trap_id:
           type: string
           example: "nagatech"
-        display_name:
-          type: string
-          example: "ながてち"
         is_admin:
           type: boolean
     Comment:


### PR DESCRIPTION
DBのモデルに近い形に戻しました｡
またユーザの`display_name`を削除しました｡ これは次の理由に基づきます｡
- 現状Jomon単体では`display_name`を保持していないため, 外と通信しない限り取得することができない
- このサービスの目的の性質上変更可能な`display_name`は混乱を招きうる