### PR TITLE
モックの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ This is an accounting support system ,"Jomon".
 ```shell script
 docker-compose -f server-test.yml run --rm jomon-server
 ```
+### Client
+1. Run following command in the project root.
+```shell script
+docker-compose -f mock-for-client.yml up
+```
+Now you can access to `http://localhost:3000` for Jomon client page.
+And you can access to `http://localhost:1323` for Jomon mock server using `swagger.yaml`.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -43,7 +43,7 @@ paths:
           required: false
           in: query
           schema:
-            type: string
+            $ref: "#/components/schemas/TrapID"
         - name: type
           description: どのタイプか（"club","contest","event","public")
           in: query
@@ -426,8 +426,7 @@ paths:
                 type: object
                 properties:
                   trap_id:
-                    type: string
-                    example: "nagatech"
+                    $ref: "#/components/schemas/TrapID"
                   to_admin:
                     type: boolean
       responses:
@@ -452,6 +451,10 @@ components:
     StateEnum:
       type: string
       enum: [submitted, fix_required, accepted, fully_repaid, rejected]
+    TrapID:
+      type: string
+      pattern: "^[0-9a-zA-Z_]{1,32}$"
+      example: "nagatech"
     CompactApplication:
       type: object
       properties:
@@ -536,12 +539,12 @@ components:
             amount:
               type: integer
               minimum: 1
+              maximum: 2147483647
               example: 1200
             repaid_to_id:
               type: array
               items:
-                type: string
-                example: "nagatech"
+                $ref: "#/components/schemas/TrapID"
               uniqueItems: true
               minItems: 1
         images:
@@ -553,8 +556,7 @@ components:
       type: object
       properties:
         trap_id:
-          type: string
-          example: "nagatech"
+          $ref: "#/components/schemas/TrapID"
         is_admin:
           type: boolean
     Comment:

--- a/mock-for-client.yml
+++ b/mock-for-client.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  proxy:
+    image: nginx
+    ports:
+      - "3000:80"
+    volumes:
+      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - jomon-server
+      - jomon-client
+
+  jomon-server:
+    image: swaggermock/swagger-mock
+    environment:
+      SWAGGER_MOCK_SPECIFICATION_URL: "/docs/swagger.yaml"
+    ports:
+      - '1323:8080'
+    volumes:
+      - './docs:/docs'
+
+  jomon-client:
+    build: ./client
+    volumes:
+      - './client/app'
+    tty: true
+    entrypoint: npm run serve


### PR DESCRIPTION
`docker-compose -f ${PROJECT_ROOT}/mock-for-client.yml up` で動きます｡
まともなレスポンスを返すために多少swaggerを書き換えました｡

Closes #26