### PR TITLE
fix swagger

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -517,6 +517,12 @@ components:
         paid_at:
           type: string
           format: date
+        repaid_to_id:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrapID"
+          uniqueItems: true
+          minItems: 1
         updated_at:
           type: string
           format: date-time


### PR DESCRIPTION
申請書詳細情報に払い戻しリストがなくなっていたことに気づいたので該当箇所に追加