### PR TITLE
detail_logsのUpdateAtが更新されるようにした

### DIFF
--- a/model/applications_detail.go
+++ b/model/applications_detail.go
@@ -150,6 +150,8 @@ func (_ *applicationRepository) putApplicationsDetail(db_ *gorm.DB, currentDetai
 		detail.PaidAt.PaidAt = *paidAt
 	}
 
+	detail.UpdatedAt = time.Time{} // zero value
+
 	err = db_.Create(&detail).Error
 	if err != nil {
 		return ApplicationsDetail{}, err


### PR DESCRIPTION
- `putApplicationsDetail`にて`Find`してきた`detail`の`UpdateAt`がそのまま使われていたので、ゼロ値で初期化してDBテーブルに追加した時点での時刻が挿入されるようにした
- `time.Now()`を入れた方が明確かもしれない？

close #91 