### PR TITLE
sess.Optionsを全てのsessに追加

### DIFF
--- a/router/auth.go
+++ b/router/auth.go
@@ -47,6 +47,12 @@ func (s Service) AuthCallback(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
+	sess.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   sessionDuration,
+		HttpOnly: true,
+	}
+
 	codeVerifier, ok := sess.Values[sessionCodeVerifierKey].(string)
 	if !ok {
 		return c.NoContent(http.StatusInternalServerError)
@@ -57,11 +63,6 @@ func (s Service) AuthCallback(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
-	sess.Options = &sessions.Options{
-		Path:     "/",
-		MaxAge:   sessionDuration,
-		HttpOnly: true,
-	}
 	sess.Values[sessionAccessTokenKey] = res.AccessToken
 	sess.Values[sessionRefreshTokenKey] = res.RefreshToken
 
@@ -82,6 +83,12 @@ func (s Service) GeneratePKCE(c echo.Context) error {
 	sess, err := session.Get(sessionKey, c)
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	sess.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   sessionDuration,
+		HttpOnly: true,
 	}
 
 	bytesCodeVerifier := generateCodeVerifier()

--- a/router/service.go
+++ b/router/service.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/Jomon/model"
@@ -46,6 +47,12 @@ func (s Service) AuthUser(c echo.Context) (echo.Context, error) {
 	sess, err := session.Get(sessionKey, c)
 	if err != nil {
 		return nil, c.NoContent(http.StatusInternalServerError)
+	}
+
+	sess.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   sessionDuration,
+		HttpOnly: true,
 	}
 
 	accTok, ok := sess.Values[sessionAccessTokenKey].(string)


### PR DESCRIPTION
https://stackoverflow.com/questions/21865681/sessions-variables-in-golang-not-saved-while-using-gorilla-sessions の
> Your sessions aren't "sticking" is that you're setting the Path as /loginSession - so when a user visits any other path (i.e. /), the session isn't valid for that scope.

だと思ったのでsessionが全部のパスで有効になるかなと思って全部に追加しました。できるかはわからず......