### PR TITLE
dockerチューニング

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.*
+Jomon
+docker
+Dockerfile
+*.yaml
+README.md
+Makefile
+node_modules
+uploads
+docs

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,2 +1,6 @@
+README.md
+Dockerfile
+.dockerignore
 node_modules
 dist
+src

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:lts-alpine AS build
 WORKDIR /app
-RUN apk add --no-cache git && \
-    apk --update add tzdata && \
-    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
-    apk del tzdata && \
-    rm -rf /var/cache/apk/*
 
-COPY package*.json ./
+ENV TZ Asia/Tokyo
+
+RUN apk --update --no-cache add git
+RUN apk --update --no-cache add tzdata && \
+    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
+    apk del tzdata
+
+COPY package.json package-lock.json ./
 RUN npm ci
+
 COPY . .

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,28 +1,28 @@
 FROM golang:1.13.5-alpine as build
 ENV DOCKERIZE_VERSION v0.6.1
 ENV CGO_ENABLED 0
-ARG GO_BUILD_TAGS=''
+ENV TZ Asia/Tokyo
 
+ARG GO_BUILD_TAGS=''
 RUN echo $GO_BUILD_TAGS
 
-RUN apk add --update --no-cache ca-certificates git openssl curl \
-    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+RUN apk add --update --no-cache git
+RUN apk --update --no-cache add tzdata \
+    && cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime \
+    && apk del tzdata
+RUN apk --update --no-cache add ca-certificates \
+    && update-ca-certificates \
+    && rm -rf /usr/share/ca-certificates /etc/ssl/certificates
+
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+RUN wget https://github.com/go-task/task/releases/download/v3.0.0/task_linux_386.tar.gz \
+    && tar -C /usr/local/bin -zxvf task_linux_386.tar.gz task \
+    && rm task_linux_386.tar.gz
 
 WORKDIR /src
 
 COPY go.mod go.sum ./
 RUN go mod download
-
-RUN git clone https://github.com/go-task/task task_prj \
-    && cd task_prj \
-    && go install -v ./cmd/task \
-    && go build -v -o ./task ./cmd/task \
-    && cd .. \
-    && mv ./task_prj/task ./task \
-    && rm -rf task_prj
-
-COPY . .
-
-RUN go build -tags $GO_BUILD_TAGS -o /app/Jomon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: jomon
+      TZ: Asia/Tokyo
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     expose:
       - '3306'

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -6,7 +6,6 @@ services:
       context: ../../
       dockerfile: ./Dockerfile
     env_file: ../../.env
-    entrypoint: dockerize -wait tcp://db:3306 -timeout 60s
     command: /app/Jomon
     environment:
       MARIADB_USERNAME: root
@@ -15,10 +14,7 @@ services:
       MARIADB_DATABASE: jomon
     ports:
       - '1323:1323'
-    volumes:
-      - '../../:/src'
-    depends_on:
-      - db
+    restart: always
 
   db:
     image: mariadb:10.3.9
@@ -27,6 +23,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: jomon
+      TZ: Asia/Tokyo
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     expose:
       - '3306'


### PR DESCRIPTION
staging、developmentのdocker関連諸々を調整した。
- 無駄にopenssl、curlを入れているところの排除
- ca-certificateのupdateをしていなかったのでupdateするようにする
- dockerignoreがcontext以外のディレクトリに置かれていて効いていなかったのでcontextに置くように
- go-taskを毎回gitで取ってきてビルドしていたのをバイナリのダウンロードでインストールするように
- つなぐ必要性のないコマンドを切って可読性を向上
- developmentでは起動時にボリュームのマウントとgoのbuildが行われるのでdevelopmentのDockerfileからこの部分を排除
- mysqlのタイムゾーンが設定されていなかったので設定

チューニング前
![image](https://user-images.githubusercontent.com/50093633/93660763-1e113b80-fa8d-11ea-950a-46d9d5066938.png)

チューニング後
![image](https://user-images.githubusercontent.com/50093633/93660814-b5768e80-fa8d-11ea-8318-33ed5f57b7b4.png)

