### PR TITLE
Goを1.17.5にアップデート:genbacat:

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,5 @@
 name: Go
-on:
-  push:
-    paths:
-    - "**.go"
-    - "go.mod"
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.17.5
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17.5
       id: go
 
     - name: Check out code into the Go module directory
@@ -46,10 +46,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.17.5
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.17.5
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ## build backend
-FROM golang:1.13.5-alpine as server-build
+FROM golang:1.17.5-alpine as server-build
 
 WORKDIR /github.com/traPtitech/Jomon
 COPY go.mod go.sum ./

--- a/development/Dockerfile
+++ b/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5-alpine as build
+FROM golang:1.17.5-alpine as build
 ENV DOCKERIZE_VERSION v0.6.1
 ENV CGO_ENABLED 0
 ENV TZ Asia/Tokyo


### PR DESCRIPTION
https://github.com/golang/go/issues/36524 の修正がほしい
Goしかあげてないからmariadbとかもあげたほうがいいのかも