### PR TITLE
swagger-latestに合わせる修正

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,42 +6,58 @@ info:
   version: "2.0.0"
   title: Jomon API
   description: >-
+
     JomonのAPIです。
+
+tags:
+- name: "Auth"
+  description: "認証用API"
+- name: "Transactions"
+  description: "トランザクションに関するAPI"
+- name: "Requests"
+  description: "リクエストに関するAPI"
+- name: "File"
+  description: "ファイルに関するAPI"
+- name: "Tags"
+  description: "タグに関するAPI"
+- name: "Users"
+  description: "ユーザーに関するAPI"
+- name: "Groups"
+  description: "グループに関するAPI"
+- name: "Admins"
+  description: "管理者用API"
+
+##### Paths #####
+
 paths:
-  "/auth/genpkce":
+  /auth/genpkce:
     get:
+      operationId: generatePKCE
       description: PKCEを取得する｡
       tags:
         - Auth
       responses:
         "200":
-          description: 取得できた｡
+          description: 取得できた場合｡
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  code_challenge:
-                    type: string
-                  code_challenge_method:
-                    type: string
-                  client_id:
-                    type: string
-                  response_type:
-                    type: string
-  "/transactions":
+                $ref: "#/components/schemas/AuthInfo"
+
+  /transactions:
     get:
+      operationId: "getTransactions"
       description: トランザクション一覧を取得する。
       tags:
         - Transactions
       parameters:
-        - $ref: "#/components/parameters/sortTransactionQuery"
+        - $ref: "#/components/parameters/sortQuery"
         - $ref: "#/components/parameters/targetQuery"
-        - $ref: "#/components/parameters/yearQuery"
         - $ref: "#/components/parameters/sinceQuery"
         - $ref: "#/components/parameters/untilQuery"
         - $ref: "#/components/parameters/tagQuery"
         - $ref: "#/components/parameters/groupQuery"
+        - $ref: "#/components/parameters/requestQuery"
       responses:
         "200":
           description: 該当するものがない場合は空配列を返却。
@@ -54,6 +70,7 @@ paths:
         "400":
           $ref: "#/components/responses/400"
     post:
+      operationId: postTransaction
       description: トランザクションを新規作成する。管理者権限が必要。
       tags:
         - Transactions
@@ -70,11 +87,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Transaction"
-
         "400":
           $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
 
-  "/transactions/{transactionID}":
+  /transactions/{transactionID}:
     parameters:
       - name: transactionID
         in: path
@@ -83,6 +101,7 @@ paths:
           type: string
           format: uuid
     get:
+      operationId: getTransactionDetail
       description: 指定したトランザクションの詳細を取得する。
       tags:
         - Transactions
@@ -96,7 +115,8 @@ paths:
         "404":
           $ref: "#/components/responses/404"
     put:
-      description: 指定したTransactionを修正する。管理者権限が必要。
+      operationId: putTransactionDetail
+      description: 指定したTransactionを修正する。管理者権限が必要。requestに紐づいている場合は変更不可。
       tags:
         - Transactions
       requestBody:
@@ -118,22 +138,24 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  "/requests":
+
+  /requests:
     get:
+      operationId: getRequests
       description: 依頼一覧を取得する。
       tags:
         - Requests
       parameters:
-        - $ref: "#/components/parameters/sortRequestQuery"
+        - $ref: "#/components/parameters/sortQuery"
+        - $ref: "#/components/parameters/currentStatusQuery"
         - $ref: "#/components/parameters/targetQuery"
-        - $ref: "#/components/parameters/yearQuery"
         - $ref: "#/components/parameters/sinceQuery"
         - $ref: "#/components/parameters/untilQuery"
         - $ref: "#/components/parameters/tagQuery"
         - $ref: "#/components/parameters/groupQuery"
       responses:
         "200":
-          description: 取得できた。返す。該当するものがなくても空配列を返す。
+          description: 取得できた場合。該当するものがなくても空配列を返す。
           content:
             application/json:
               schema:
@@ -143,6 +165,7 @@ paths:
         "400":
           $ref: "#/components/responses/400"
     post:
+      operationId: postRequest
       description: 依頼を新規作成する。
       tags:
         - Requests
@@ -154,15 +177,15 @@ paths:
               $ref: "#/components/schemas/PostRequest"
       responses:
         "201":
-          description: 作成した。結果を返す。
+          description: 作成できた場合。作成されたリクエストの詳細を返す。
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/RequestDetail"
-
         "400":
           $ref: "#/components/responses/400"
-  "/requests/{requestID}":
+
+  /requests/{requestID}:
     parameters:
       - name: requestID
         in: path
@@ -171,6 +194,7 @@ paths:
           type: string
           format: uuid
     get:
+      operationId: getRequestDetail
       description: 指定した依頼の詳細を取得する。
       tags:
         - Requests
@@ -184,6 +208,7 @@ paths:
         "404":
           $ref: "#/components/responses/404"
     put:
+      operationId: putRequestDetail
       description: 指定した依頼を修正する。作成者権限が必要。
       tags:
         - Requests
@@ -195,7 +220,7 @@ paths:
               $ref: "#/components/schemas/PostRequest"
       responses:
         "200":
-          description: 修正できた。返す。
+          description: 修正できた場合。修正後の詳細を返す。
           content:
             application/json:
               schema:
@@ -206,8 +231,10 @@ paths:
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  "/requests/{requestID}/comments":
+
+  /requests/{requestID}/comments:
     post:
+      operationId: postComment
       description: 指定した依頼にコメントを新規作成する。
       tags:
         - Requests
@@ -223,11 +250,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                comment:
-                  type: string
-                  example: "ここを修正してください。"
+              $ref: "#/components/schemas/PostComment"
       responses:
         "201":
           description: OK
@@ -239,9 +262,11 @@ paths:
           $ref: "#/components/responses/400"
         "404":
           $ref: "#/components/responses/404"
-  "/requests/{requestID}/status":
+
+  /requests/{requestID}/status:
     put:
-      description: 指定した依頼のstatusを変更のみ(新規はpost /requests)する。reasonは常に必須(ないときは空文字列)。statusの行き来の定義は作成者は「fix_requiredからsubmitted」をでき、adminは「submittedからrejected」「submittedからrequired」「fix_requiredからsubmitted」「submittedからaccepted」「acceptedからsubmitted（ただしすでに支払われている人がいた場合、この操作は不可)」の操作のみ可。ただし、「acceptedからcompleted」の操作はここでは行えない。管理者権限または作成者権限が必要。
+      operationId: putStatus
+      description: 指定した依頼のstatusを変更のみ(新規はpost /requests)する。commentは常に必須(ないときは空文字列)。statusの行き来の定義は作成者は「fix_requiredからsubmitted」をでき、adminは「submittedからrejected」「submittedからrequired」「fix_requiredからsubmitted」「submittedからaccepted」「acceptedからsubmitted（ただしすでに支払われている人がいた場合、この操作は不可)」の操作のみ可。ただし、「acceptedからfully_repaid」の操作はここでは行えない。管理者権限または作成者権限が必要。
       tags:
         - Requests
       parameters:
@@ -256,13 +281,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                status:
-                  $ref: "#/components/schemas/StatusEnum"
-                reason:
-                  type: string
-                  example: "良いですね。"
+              $ref: "#/components/schemas/PutStatus"
       responses:
         "200":
           description: OK
@@ -274,21 +293,28 @@ paths:
           $ref: "#/components/responses/400"
         "404":
           $ref: "#/components/responses/404"
-  "/admins":
+
+  /admins:
     get:
+      operationId: getAdmins
       description: adminユーザーの一覧を返す。管理者権限が必要。
       tags:
         - Admins
       responses:
         "200":
-          description: 取得に成功した。返す
+          description: 取得に成功した場合。
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: "#/components/schemas/TrapID"
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
     post:
+      operationId: postAdmins
       description: adminユーザーを追加する。管理者権限が必要。
       tags:
         - Admins
@@ -297,71 +323,56 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                id:
-                  $ref: "#/components/schemas/TrapID"
+              type: array
+              items:
+                $ref: "#/components/schemas/TrapID"
       responses:
         "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    $ref: "#/components/schemas/TrapID"
+          description: 追加に成功した場合。
         "400":
           $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
-        "404":
-          $ref: "#/components/responses/404"
-  "/admins/{userID}":
     delete:
+      operationId: deleteAdmins
       description: adminユーザーを削除する。管理者権限が必要。
       tags:
         - Admins
-      parameters:
-        - name: userID
-          in: path
-          required: true
-          schema:
-            $ref: "#/components/schemas/TrapID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/TrapID"
       responses:
         "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    $ref: "#/components/schemas/TrapID"
+          description: 削除できた場合。
         "400":
           $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  "/tags":
+
+  /tags:
     get:
+      operationId: getTags
       description: タグの一覧を返す。
       tags:
         - Tags
       responses:
         "200":
-          description: 取得に成功した。返す
+          description: 取得に成功した場合。
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  tags:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Tag"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Tag"
     post:
+      operationId: postTag
       description: タグを追加する。
       tags:
         - Tags
@@ -373,12 +384,15 @@ paths:
               $ref: "#/components/schemas/PostTag"
       responses:
         "200":
-          description: 追加に成功した。
+          description: 追加に成功した場合。追加されたタグの情報を返す。
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Tag"
-  "/tags/{tagID}":
+        "400":
+          $ref: "#/components/responses/400"
+
+  /tags/{tagID}:
     parameters:
       - name: tagID
         in: path
@@ -392,42 +406,11 @@ paths:
         - Tags
       responses:
         "200":
-          description: 取得に成功した。
+          description: 取得に成功した場合。
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: "#/components/schemas/Tag"
-                  - type: object
-                    properties:
-                      transactions:
-                        type: array
-                        items:
-                          type: string
-                          format: uuid
-                      requests:
-                        type: array
-                        items:
-                          type: string
-                          format: uuid
-        "404":
-          $ref: "#/components/responses/404"
-    put:
-      description: タグの情報を変更する。
-      tags:
-        - Tags
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/PostTag"
-      responses:
-        "200":
-          description: 変更に成功した。
-          content:
-            application/json:
-              schema:
+                # なにこれ
                 allOf:
                   - $ref: "#/components/schemas/Tag"
                   - type: object
@@ -450,27 +433,27 @@ paths:
         - Tags
       responses:
         "200":
-          description: 削除に成功した。
+          description: 削除に成功した場合。
         "404":
           $ref: "#/components/responses/404"
-  "/groups":
+
+  /groups:
     get:
+      operationId: getGroups
       description: グループの一覧を返す。
       tags:
         - Groups
       responses:
         "200":
-          description: 取得に成功した。返す
+          description: 取得に成功した場合。
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  groups:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/Group"
+                type: array
+                items:
+                  $ref: "#/components/schemas/Group"
     post:
+      operationId: postGroup
       description: グループを追加する。管理者権限が必要。
       tags:
         - Groups
@@ -482,12 +465,17 @@ paths:
               $ref: "#/components/schemas/PostGroup"
       responses:
         "200":
-          description: 追加に成功した。
+          description: 追加に成功した場合。
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Group"
-  "/groups/{groupID}":
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+
+  /groups/{groupID}:
     parameters:
       - name: groupID
         in: path
@@ -496,6 +484,7 @@ paths:
           type: string
           format: uuid
     put:
+      operationId: putGroupDetail
       description: グループの情報を変更する。管理者権限またはグループオーナー権限が必要。
       tags:
         - Groups
@@ -504,26 +493,34 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PostGroup"
+              $ref: "#/components/schemas/PutGroup"
       responses:
         "200":
-          description: 変更に成功した。
+          description: 変更に成功した場合。
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Group"
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
     delete:
+      operationId: deleteGroup
       description: グループを削除する。管理者権限またはグループオーナー権限が必要。
       tags:
         - Groups
       responses:
         "200":
-          description: 削除に成功した。
+          description: 削除に成功した場合
+        "403":
+          $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
-  "/groups/{groupID}/members":
+
+  /groups/{groupID}/members:
     parameters:
       - name: groupID
         in: path
@@ -532,24 +529,23 @@ paths:
           type: string
           format: uuid
     get:
+      operationId: getGroupMembers
       description: 指定したグループに所属しているユーザーを返す。
       tags:
         - Groups
       responses:
         "200":
-          description: 取得に成功した。返す
+          description: 取得に成功した場合。
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  members:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/TrapID"
+                type: array
+                items:
+                  $ref: "#/components/schemas/TrapID"
         "404":
           $ref: "#/components/responses/404"
     post:
+      operationId: postGroupMembers
       description: ユーザーをグループに追加する。管理者権限またはグループオーナー権限が必要。
       tags:
         - Groups
@@ -558,23 +554,42 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                id:
-                  $ref: "#/components/schemas/TrapID"
+              type: array
+              items:
+                $ref: "#/components/schemas/TrapID"
       responses:
         "200":
-          description: 追加に成功した。
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    type: array
-                    items:
-                    $ref: "#/components/schemas/TrapID"
-  "/groups/{groupID}/owners/{memberID}":
+          description: 追加に成功した場合。
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+    delete:
+      operationId: deleteGroupMembers
+      description: ユーザーをグループのメンバーから外す。管理者権限またはグループオーナー権限が必要。
+      tags:
+        - Group
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/TrapID"
+      responses:
+        "200":
+          description: 削除に成功した場合。
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+
+  /groups/{groupID}/owners:
     parameters:
       - name: groupID
         in: path
@@ -588,40 +603,8 @@ paths:
         schema:
           type: string
           format: uuid
-    delete:
-      description: ユーザーをグループから削除する。管理者権限またはグループオーナー権限が必要。
-      tags:
-        - Groups
-      responses:
-        "200":
-          description: 削除に成功した。
-  "/groups/{groupID}/owners":
-    parameters:
-      - name: groupID
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-    get:
-      description: 指定したグループに所属しているグループオーナーを返す。
-      tags:
-        - Groups
-      responses:
-        "200":
-          description: 取得に成功した。返す
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  owners:
-                    type: array
-                    items:
-                      $ref: "#/components/schemas/TrapID"
-        "404":
-          $ref: "#/components/responses/404"
     post:
+      operationId: postGroupOwners
       description: グループオーナーをグループに追加する。管理者権限またはグループオーナー権限が必要。
       tags:
         - Groups
@@ -630,44 +613,36 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                id:
-                  $ref: "#/components/schemas/TrapID"
+              type: array
+              items:
+                $ref: "#/components/schemas/TrapID"
       responses:
         "200":
-          description: 追加に成功した。
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  id:
-                    $ref: "#/components/schemas/TrapID"
-  "/groups/{groupID}/owners/{ownerID}":
-    parameters:
-      - name: groupID
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
-      - name: ownerID
-        in: path
-        required: true
-        schema:
-          type: string
-          format: uuid
+          description: 追加に成功した場合。
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
     delete:
-      description: グループオーナーをグループから削除する。管理者権限またはグループオーナー権限が必要。
+      operationId: deleteGroupOwners
+      description: ユーザーをグループから削除する。管理者権限またはグループオーナー権限が必要。
       tags:
         - Groups
       responses:
         "200":
-          description: 削除に成功した。
+          description: 削除に成功した場合。
+        "400":
+          $ref: "#/components/responses/400"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
 
-  "/files":
+  /files:
     post:
+      operationId: postFile
       description: ファイルをアップロードする。
       tags:
         - Files
@@ -679,7 +654,7 @@ paths:
               $ref: "#/components/schemas/PostFile"
       responses:
         "200":
-          description: 変更に成功した。
+          description: 変更に成功した場合。
           content:
             application/json:
               schema:
@@ -690,7 +665,8 @@ paths:
                     format: uuid
         "400":
           $ref: "#/components/responses/400"
-  "/files/{fileID}":
+
+  /files/{fileID}:
     parameters:
       - name: fileID
         in: path
@@ -699,6 +675,7 @@ paths:
           type: string
           format: uuid
     get:
+      operationId: getFile
       tags:
         - Files
       description: 指定されたファイルを返す
@@ -712,25 +689,51 @@ paths:
         "404":
           $ref: "#/components/responses/404"
     delete:
+      operationId: deleteFile
       description: 指定したidのファイルを削除する。管理者権限または作成者権限が必要。
       tags:
         - Files
       responses:
         "204":
-          description: 正常に取り消すことができた。
+          description: 正常に取り消すことができた場合。
+        "400":
+          $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
         "404":
           $ref: "#/components/responses/404"
 
+  /files/{fileID}/meta:
+    parameters:
+      - name: fileID
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      operationId: getFileMeta
+      description: 指定されたファイルのメタデータを返す
+      tags:
+        - Files
+      responses:
+        "200":
+          description: 該当するファイルのメタデータが存在した 返す
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileMeta"
+        "404":
+          $ref: "#/components/responses/404"
 
   /users:
     get:
-      tags:
-      - "Users"
+      operationId: getUsers
       description: "ユーザー一覧を取得する。"
+      tags:
+        - "Users"
       responses:
-        '200':
+        "200":
           description: "OK"
           content:
             application/json:
@@ -738,43 +741,69 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/User"
+
+  /users/{userID}:
+    parameters:
+      - name: userID
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
     put:
-      tags:
-      - "Users"
+      operationId: putUserDetail
       description: "ユーザーの情報を変更する。主に権限の変更用。管理者権限またはグループオーナー権限が必要。"
+      tags:
+        - "Users"
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PostUser"
+              $ref: "#/components/schemas/PutUser"
       responses:
-        '200':
-          description: "取得に成功した。返す"
+        "200":
+          description: "取得に成功した場合。"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/User"
-        '400':
+        "400":
           $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
 
   /users/me:
     get:
-      tags:
-      - "Users"
+      operationId: getMe
       description: "自分の情報を取得する。存在しない場合はユーザーを作成する。"
+      tags:
+        - "Users"
       responses:
-        '200':
-          description: "取得に成功した。返す"
+        "200":
+          description: "取得に成功した場合。"
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/User"
 
+##### Components #####
+
 components:
   schemas:
+    AuthInfo: 
+      type: object
+      properties:
+        code_challenge:
+          type: string
+        code_challenge_method:
+          type: string
+        client_id:
+          type: string
+        response_type:
+          type: string
     StatusEnum:
       type: string
       enum: [submitted, fix_required, accepted, completed, rejected]
@@ -790,9 +819,6 @@ components:
         name:
           type: string
           example: "2020講習会"
-        description:
-          type: string
-          example: "2020年度講習会"
         created_at:
           type: string
           format: date-time
@@ -805,9 +831,6 @@ components:
         name:
           type: string
           example: "2020講習会"
-        description:
-          type: string
-          example: "2020年度講習会"
     Group:
       type: object
       properties:
@@ -841,6 +864,27 @@ components:
         budget:
           type: integer
           example: 250000
+    PutGroup:
+      type: object
+      properties:
+        name:
+          type: string
+          example: "SysAd"
+        description:
+          type: string
+          example: "SysAd班"
+        budget:
+          type: integer
+          example: 250000
+    File:
+      type: object
+      properties:
+        file:
+          type: string
+          format: binary
+        name:
+          type: string
+          example: "hoge.png"
     PostFile:
       type: object
       properties:
@@ -853,18 +897,38 @@ components:
         request_id:
           type: string
           format: uuid
-    File:
+    FileMeta:
       type: object
       properties:
-        file:
+        id:
           type: string
-          format: binary
+          format: uuid
         name:
           type: string
-          example: "hoge.png"
+        mime_type:
+          type: string
+        created_at:
+          type: string
+          format: date-time
     Target:
       type: string
       example: "hoge株式会社"
+    TargetDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        amount:
+          type: integer
+        target:
+          type: string
+        paid_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
     Request:
       type: object
       properties:
@@ -903,6 +967,8 @@ components:
         id:
           type: string
           format: uuid
+        status:
+          $ref: "#/components/schemas/StatusEnum"
         amount:
           type: integer
           example: 1200
@@ -912,6 +978,9 @@ components:
         content:
           type: string
           example: "サーバー代 1200円"
+        created_by:
+          type: string
+          format: uuid
         comments:
           type: array
           items:
@@ -931,6 +1000,10 @@ components:
             $ref: "#/components/schemas/Tag"
         group:
           $ref: "#/components/schemas/Group"
+        targets:
+          type: array
+          items:
+            $ref: "#/components/schemas/TargetDetail"
         created_at:
           type: string
           format: date-time
@@ -954,9 +1027,11 @@ components:
         tags:
           type: array
           items:
-            $ref: "#/components/schemas/PostTag"
+            type: string
+            format: uuid
         group:
-          $ref: "#/components/schemas/PostGroup"
+          type: string
+          format: uuid
     Transaction:
       type: object
       properties:
@@ -968,6 +1043,9 @@ components:
           example: 1200
         target:
           $ref: "#/components/schemas/Target"
+        request:
+          type: string
+          format: uuid
         tags:
           type: array
           items:
@@ -986,14 +1064,19 @@ components:
         amount:
           type: integer
           example: 1200
-        target:
-          $ref: "#/components/schemas/Target"
+        targets:
+          type: array
+          items:
+            $ref: "#/components/schemas/Target"
         tags:
           type: array
           items:
             type: string
             format: uuid
         group:
+          type: string
+          format: uuid
+        request:
           type: string
           format: uuid
     Comment:
@@ -1013,6 +1096,12 @@ components:
         updated_at:
           type: string
           format: date-time
+    PostComment:
+      type: object
+      properties:
+        comment:
+          type: string
+          example: "ここを修正してください。"
     Status:
       type: object
       properties:
@@ -1020,13 +1109,21 @@ components:
           $ref: "#/components/schemas/TrapID"
         status:
           $ref: "#/components/schemas/StatusEnum"
-        reason:
+        comment:
           type: string
           default: null
           example: "これは雑すぎますね。"
         created_at:
           type: string
           format: date-time
+    PutStatus:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/StatusEnum"
+        comment:
+          type: string
+          example: "良いですね。"
     User:
       type: "object"
       properties:
@@ -1047,7 +1144,7 @@ components:
         deleted_at:
           type: "string"
           format: "date-time"
-    PostUser:
+    PutUser:
       type: "object"
       properties:
         name:
@@ -1067,16 +1164,16 @@ components:
       description: 指定したリソースは存在しない。
 
   parameters:
-    sortRequestQuery:
+    sortQuery:
       name: sort
       description: 並び順 (作成日時が新しい "created_at", 作成日時が古い "-created_at", タイトルの昇順 "title", タイトルの降順 "-title")
       required: false
       in: query
       schema:
         type: string
-    sortTransactionQuery:
-      name: sort
-      description: 並び順 (作成日時が新しい "created_at", 作成日時が古い "-created_at")
+    currentStatusQuery:
+      name: current_status
+      description: 現在の状態
       required: false
       in: query
       schema:
@@ -1088,13 +1185,6 @@ components:
       in: query
       schema:
         type: string
-    yearQuery:
-      name: year
-      description: 何年度の依頼か
-      required: false
-      in: query
-      schema:
-        type: integer
     sinceQuery:
       name: since
       description: いつからの依頼か
@@ -1125,3 +1215,11 @@ components:
       in: query
       schema:
         type: string
+    requestQuery:
+      name: request
+      description: 依頼
+      required: False
+      in: query
+      schema:
+        type: string
+        format: uuid


### PR DESCRIPTION
Swagger変更点一覧
- operationIdの追加: この名前でクライアントの関数がコード生成される
- 各種オブジェクトの切り出し: この名前でクライアントの型が定義される
- 「adminの追加、削除」「groupのowner/memberの追加、削除」を配列に＆レスポンスボディを省略
  - 無駄にObjectでwrapしていたschemaのunwrap
- getRequestDetailに現在のstatusの追加
- deleteGroupMemberの移動
- 欠けていたレスポンスの追加
- putUserDetailを`/users`から`/users/{userID}`に
  - 一旦request bodyに変更なし

疑問（過去にそれで良さっていっちゃったかも？ or 過去にどんな議論したか忘れた）
- putStatusの`commentは常に必須(ないときは空文字列)。`
  - TODO: 要確認
- tagsでtagに関連するtransactionとrequestsをとってきてる
  - これは表示したいならそれぞれ別でリクエストを送ったほうが良い
- getGroupがない
  - TODO: 要確認
- getGroupMembersはGroupの情報でとって良さそう
  - TODO: 要確認
- post/deleteTagに権限に関する旨がない
  - これ権限必要じゃなかったっけ？
  - TODO: 要確認
- post/deleteTagに権限に関する旨がない
  - これ権限必要じゃなかったっけ？


これの変更点に伴う修正