### PR TITLE
go buildのオプションに-buildvcs=falseを追加

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,7 +7,7 @@ tmp_dir = "tmp"
 
 [build]
 # Just plain old shell command. You could use `make` as well.
-cmd = "go build -o ./tmp/main ."
+cmd = "go build -buildvcs=false -o ./tmp/main ."
 # Binary file yields from `cmd`.
 bin = "tmp/main"
 # Customize binary.


### PR DESCRIPTION
https://github.com/traPtitech/portal/pull/150/commits/aa7c1412c9abefd68481b362fbc788a62a316e3e
と同じ