### PR TITLE
loggingでerror等が正しく表示されるように修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	} else {
 		logger, err = zap.NewProduction()
 	}
+	defer logger.Sync()
 	if err != nil {
 		panic(err)
 	}

--- a/router/auth.go
+++ b/router/auth.go
@@ -37,7 +37,6 @@ func (h Handlers) AuthCallback(c echo.Context) error {
 
 	sess, err := h.SessionStore.Get(c.Request(), h.SessionName)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
@@ -49,26 +48,22 @@ func (h Handlers) AuthCallback(c echo.Context) error {
 
 	codeVerifier, ok := sess.Values[sessionCodeVerifierKey].(string)
 	if !ok {
-		c.Logger().Error(err)
 		return echo.ErrInternalServerError
 	}
 
 	res, err := service.RequestAccessToken(code, codeVerifier)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
 	u, err := service.FetchTraQUserInfo(res.AccessToken)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
 	ctx := context.Background()
 	modelUser, err := h.Repository.GetUserByName(ctx, u.Name)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
@@ -83,7 +78,6 @@ func (h Handlers) AuthCallback(c echo.Context) error {
 	sess.Values[sessionUserKey] = user
 
 	if err = sess.Save(c.Request(), c.Response()); err != nil {
-		c.Logger().Error(err)
 		return echo.ErrInternalServerError
 	}
 
@@ -94,7 +88,6 @@ func (h Handlers) GeneratePKCE(c echo.Context) error {
 	gob.Register(&User{})
 	sess, err := h.SessionStore.Get(c.Request(), h.SessionName)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
@@ -114,7 +107,6 @@ func (h Handlers) GeneratePKCE(c echo.Context) error {
 
 	err = sess.Save(c.Request(), c.Response())
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/router/group.go
+++ b/router/group.go
@@ -112,7 +112,6 @@ func (h *Handlers) PutGroup(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -141,7 +140,6 @@ func (h *Handlers) DeleteGroup(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -161,7 +159,6 @@ func (h *Handlers) GetMembers(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -194,7 +191,6 @@ func (h *Handlers) PostMember(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -219,7 +215,6 @@ func (h *Handlers) DeleteMember(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -228,7 +223,6 @@ func (h *Handlers) DeleteMember(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if memberID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -252,7 +246,6 @@ func (h *Handlers) GetOwners(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 	owners, err := h.Repository.GetOwners(ctx, groupID)
@@ -280,7 +273,6 @@ func (h *Handlers) PostOwner(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 	if err := c.Bind(&owner); err != nil {
@@ -309,7 +301,6 @@ func (h *Handlers) DeleteOwner(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if groupID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 	ownerID, err := uuid.Parse(c.Param("ownerID"))
@@ -317,7 +308,6 @@ func (h *Handlers) DeleteOwner(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if ownerID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -7,55 +7,46 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	"github.com/traPtitech/Jomon/logging"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func (h Handlers) AccessLoggingMiddleware(logger *zap.Logger) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			start := time.Now()
-			if err := next(c); err != nil {
+			err := next(c)
+			if err != nil {
 				c.Error(err)
 			}
 			stop := time.Now()
 
 			req := c.Request()
 			res := c.Response()
-			tmp := &logging.HTTPPayload{
-				RequestMethod: req.Method,
-				Status:        res.Status,
-				UserAgent:     req.UserAgent(),
-				RemoteIP:      c.RealIP(),
-				Referer:       req.Referer(),
-				Protocol:      req.Proto,
-				RequestURL:    req.URL.String(),
-				RequestSize:   req.Header.Get(echo.HeaderContentLength),
-				ResponseSize:  strconv.FormatInt(res.Size, 10),
-				Latency:       strconv.FormatFloat(stop.Sub(start).Seconds(), 'f', 9, 64) + "s",
+			fields := []zapcore.Field{
+				zap.String("requestMethod", req.Method),
+				zap.Int("status", res.Status),
+				zap.String("userAgent", req.UserAgent()),
+				zap.String("remoteIp", c.RealIP()),
+				zap.String("referer", req.Referer()),
+				zap.String("protocol", req.Proto),
+				zap.String("requestUrl", req.URL.String()),
+				zap.String("requestSize", req.Header.Get(echo.HeaderContentLength)),
+				zap.String("responseSize", strconv.FormatInt(res.Size, 10)),
+				zap.String("latency", strconv.FormatFloat(stop.Sub(start).Seconds(), 'f', 9, 64)+"s"),
 			}
 			httpCode := res.Status
 			switch {
 			case httpCode >= 500:
-				errorRuntime, ok := c.Get("Error").(error)
-				if ok {
-					tmp.Error = errorRuntime.Error()
-				} else {
-					tmp.Error = "no data"
-				}
-				logger.Info("server error", zap.Object("field", tmp))
+				fields = append(fields, zap.Error(err))
+				logger.Error("server error", fields...)
 			case httpCode >= 400:
-				errorRuntime, ok := c.Get("Error").(error)
-				if ok {
-					tmp.Error = errorRuntime.Error()
-				} else {
-					tmp.Error = "no data"
-				}
-				logger.Info("client error", zap.Object("field", tmp))
+				fields = append(fields, zap.Error(err))
+				logger.Warn("client error", fields...)
 			case httpCode >= 300:
-				logger.Info("redirect", zap.Object("field", tmp))
-			case httpCode >= 200:
-				logger.Info("success", zap.Object("field", tmp))
+				logger.Info("redirect", fields...)
+			default:
+				logger.Info("success", fields...)
 			}
 			return nil
 		}
@@ -67,13 +58,11 @@ func (h Handlers) CheckLoginMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		gob.Register(&User{})
 		sess, err := h.SessionStore.Get(c.Request(), h.SessionName)
 		if err != nil {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 
 		_, ok := sess.Values[sessionUserKey].(*User)
 		if !ok {
-			c.Logger().Error(err)
 			return c.Redirect(http.StatusSeeOther, "/api/auth/genpkce")
 		}
 

--- a/router/request.go
+++ b/router/request.go
@@ -77,7 +77,6 @@ func (h *Handlers) GetRequests(c echo.Context) error {
 	if c.QueryParam("year") != "" {
 		year, err = strconv.Atoi(c.QueryParam("year"))
 		if err != nil {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusBadRequest, err)
 		}
 	}
@@ -85,7 +84,6 @@ func (h *Handlers) GetRequests(c echo.Context) error {
 	if c.QueryParam("since") != "" {
 		since, err = service.StrToDate(c.QueryParam("since"))
 		if err != nil {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusBadRequest, err)
 		}
 	}
@@ -93,7 +91,6 @@ func (h *Handlers) GetRequests(c echo.Context) error {
 	if c.QueryParam("until") != "" {
 		until, err = service.StrToDate(c.QueryParam("until"))
 		if err != nil {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusBadRequest, err)
 		}
 	}
@@ -111,7 +108,6 @@ func (h *Handlers) GetRequests(c echo.Context) error {
 
 	modelrequests, err := h.Repository.GetRequests(ctx, query)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
@@ -162,7 +158,6 @@ func (h *Handlers) PostRequest(c echo.Context) error {
 	var req Request
 	var err error
 	if err = c.Bind(&req); err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	var tags []*model.Tag
@@ -171,10 +166,8 @@ func (h *Handlers) PostRequest(c echo.Context) error {
 		tag, err := h.Repository.GetTag(ctx, *tagID)
 		if err != nil {
 			if ent.IsNotFound(err) {
-				c.Logger().Error(err)
 				return echo.NewHTTPError(http.StatusNotFound, err)
 			}
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 		tags = append(tags, tag)
@@ -185,10 +178,8 @@ func (h *Handlers) PostRequest(c echo.Context) error {
 		group, err = h.Repository.GetGroup(ctx, *req.Group)
 		if err != nil {
 			if ent.IsNotFound(err) {
-				c.Logger().Error(err)
 				return echo.NewHTTPError(http.StatusNotFound, err)
 			}
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 	}
@@ -196,10 +187,8 @@ func (h *Handlers) PostRequest(c echo.Context) error {
 	request, err := h.Repository.CreateRequest(ctx, req.Amount, req.Title, req.Content, tags, group, req.CreatedBy)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	var resgroup *GroupOverview
@@ -241,11 +230,9 @@ func (h *Handlers) PostRequest(c echo.Context) error {
 func (h *Handlers) GetRequest(c echo.Context) error {
 	requestID, err := uuid.Parse(c.Param("requestID"))
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if requestID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
@@ -253,15 +240,12 @@ func (h *Handlers) GetRequest(c echo.Context) error {
 	request, err := h.Repository.GetRequest(ctx, requestID)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	modelcomments, err := h.Repository.GetComments(ctx, requestID)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	var comments []*CommentDetail
@@ -317,16 +301,13 @@ func (h *Handlers) PutRequest(c echo.Context) error {
 	var err error
 	requestID, err := uuid.Parse(c.Param("requestID"))
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if requestID == uuid.Nil {
-		c.Logger().Error(errors.New("invalid UUID"))
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid UUID"))
 	}
 
 	if err = c.Bind(&req); err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	var tags []*model.Tag
@@ -335,10 +316,8 @@ func (h *Handlers) PutRequest(c echo.Context) error {
 		tag, err := h.Repository.GetTag(ctx, *tagID)
 		if err != nil {
 			if ent.IsNotFound(err) {
-				c.Logger().Error(err)
 				return echo.NewHTTPError(http.StatusNotFound, err)
 			}
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 		tags = append(tags, tag)
@@ -349,10 +328,8 @@ func (h *Handlers) PutRequest(c echo.Context) error {
 		group, err = h.Repository.GetGroup(ctx, *req.Group)
 		if err != nil {
 			if ent.IsNotFound(err) {
-				c.Logger().Error(err)
 				return echo.NewHTTPError(http.StatusNotFound, err)
 			}
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 	}
@@ -360,15 +337,12 @@ func (h *Handlers) PutRequest(c echo.Context) error {
 	request, err := h.Repository.UpdateRequest(ctx, requestID, req.Amount, req.Title, req.Content, tags, group)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	modelcomments, err := h.Repository.GetComments(ctx, requestID)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	var comments []*CommentDetail
@@ -423,28 +397,23 @@ func (h *Handlers) PutRequest(c echo.Context) error {
 func (h *Handlers) PostComment(c echo.Context) error {
 	requestID, err := uuid.Parse(c.Param("requestID"))
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if requestID == uuid.Nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
 	var req Comment
 	if err := c.Bind(&req); err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
 	sess, err := h.SessionStore.Get(c.Request(), h.SessionName)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	user, ok := sess.Values[sessionUserKey].(*User)
 	if !ok {
-		c.Logger().Error(errors.New("sessionUser not found"))
 		return echo.NewHTTPError(http.StatusUnauthorized, errors.New("sessionUser not found"))
 	}
 
@@ -452,10 +421,8 @@ func (h *Handlers) PostComment(c echo.Context) error {
 	comment, err := h.Repository.CreateComment(ctx, req.Comment, requestID, user.ID)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	res := &CommentDetail{
@@ -473,26 +440,21 @@ func (h *Handlers) PutStatus(c echo.Context) error {
 	var err error
 	requestID, err := uuid.Parse(c.Param("requestID"))
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	if requestID == uuid.Nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 	sess, err := h.SessionStore.Get(c.Request(), h.SessionName)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	user, ok := sess.Values[sessionUserKey].(*User)
 	if !ok {
-		c.Logger().Error("sessionUser not found")
 		return echo.NewHTTPError(http.StatusUnauthorized, errors.New("sessionUser not found"))
 	}
 
 	if err = c.Bind(&req); err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
@@ -500,45 +462,35 @@ func (h *Handlers) PutStatus(c echo.Context) error {
 	request, err := h.Repository.GetRequest(ctx, requestID)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
 	// judging privilege
 	if req.Status == request.Status {
-		c.Logger().Error("invalid request: same status")
 		return echo.NewHTTPError(http.StatusBadRequest, errors.New("invalid request: same status"))
 	}
 	if req.Comment == "" {
 		if !IsAbleNoCommentChangeStatus(req.Status, request.Status) {
-			message := fmt.Sprintf("unable to change %v to %v without comment", request.Status.String(), req.Status.String())
-			c.Logger().Error(message)
-			return echo.NewHTTPError(http.StatusBadRequest, errors.New(message))
+			return echo.NewHTTPError(http.StatusBadRequest, errors.New(fmt.Sprintf("unable to change %v to %v without comment", request.Status.String(), req.Status.String())))
 		}
 	}
 
 	u, err := h.Repository.GetUserByID(ctx, user.ID)
 	if err != nil {
 		if ent.IsNotFound(err) {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusNotFound, err)
 		}
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	if u.Admin {
 		if !IsAbleAdminChangeState(req.Status, request.Status) {
-			message := fmt.Sprintf("admin unable to change %v to %v", request.Status.String(), req.Status.String())
-			c.Logger().Error(message)
-			return echo.NewHTTPError(http.StatusBadRequest, errors.New(message))
+			return echo.NewHTTPError(http.StatusBadRequest, errors.New(fmt.Sprintf("admin unable to change %v to %v", request.Status.String(), req.Status.String())))
 		}
 		if req.Status == model.Submitted && request.Status == model.Accepted {
 			targets, err := h.Repository.GetRequestTargets(ctx, requestID)
 			if err != nil {
-				c.Logger().Error(err)
 				return echo.NewHTTPError(http.StatusInternalServerError, err)
 			}
 			var paid bool
@@ -549,7 +501,6 @@ func (h *Handlers) PutStatus(c echo.Context) error {
 				}
 			}
 			if paid {
-				c.Logger().Error("someone already paid")
 				return echo.NewHTTPError(http.StatusBadRequest, errors.New("someone already paid"))
 			}
 		}
@@ -557,9 +508,7 @@ func (h *Handlers) PutStatus(c echo.Context) error {
 
 	if !u.Admin && user.ID == request.CreatedBy {
 		if !IsAbleCreatorChangeStatus(req.Status, request.Status) {
-			message := fmt.Sprintf("creator unable to change %v to %v", request.Status.String(), req.Status.String())
-			c.Logger().Error(message)
-			return echo.NewHTTPError(http.StatusBadRequest, errors.New(message))
+			return echo.NewHTTPError(http.StatusBadRequest, errors.New(fmt.Sprintf("creator unable to change %v to %v", request.Status.String(), req.Status.String())))
 		}
 	}
 
@@ -570,14 +519,12 @@ func (h *Handlers) PutStatus(c echo.Context) error {
 	// create status and comment: keep the two in this order
 	created, err := h.Repository.CreateStatus(ctx, requestID, user.ID, req.Status)
 	if err != nil {
-		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 	var resComment string
 	if req.Comment != "" {
 		comment, err := h.Repository.CreateComment(ctx, req.Comment, request.ID, user.ID)
 		if err != nil {
-			c.Logger().Error(err)
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 		resComment = comment.Comment


### PR DESCRIPTION
こんな感じ
```text
jomon-server_1  | 2022-04-18T22:40:59.235+0900  ERROR   router/middleware.go:42 server error    {"requestMethod": "GET", "status": 500, "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36", "remoteIp": "172.23.0.1", "referer": "", "protocol": "HTTP/1.1", "requestUrl": "/api/auth/callback?code=G0iaX7R4we4sll95FUmlMQ2dpRMMUaNxIOT4", "requestSize": "", "responseSize": "3", "latency": "0.142614263s", "error": "code=500, message=ent: user not found"}
jomon-server_1  | github.com/traPtitech/Jomon/router.Handlers.AccessLoggingMiddleware.func1.1
jomon-server_1  |       /src/router/middleware.go:42
jomon-server_1  | github.com/labstack/echo/v4.(*Echo).ServeHTTP
jomon-server_1  |       /go/pkg/mod/github.com/labstack/echo/v4@v4.7.2/echo.go:630
jomon-server_1  | net/http.serverHandler.ServeHTTP
jomon-server_1  |       /usr/local/go/src/net/http/server.go:2916
jomon-server_1  | net/http.(*conn).serve
jomon-server_1  |       /usr/local/go/src/net/http/server.go:1966
```

```text
jomon-server_1  | github.com/traPtitech/Jomon/router.Handlers.AccessLoggingMiddleware.func1.1
jomon-server_1  |       /src/router/middleware.go:42
jomon-server_1  | github.com/labstack/echo/v4.(*Echo).ServeHTTP
jomon-server_1  |       /go/pkg/mod/github.com/labstack/echo/v4@v4.7.2/echo.go:630
jomon-server_1  | net/http.serverHandler.ServeHTTP
jomon-server_1  |       /usr/local/go/src/net/http/server.go:2916
jomon-server_1  | net/http.(*conn).serve
jomon-server_1  |       /usr/local/go/src/net/http/server.go:1966
```
ここの部分はknoQの https://github.com/traPtitech/knoQ/blob/6957f37d58a9739b4d3107cc3578755a8dafce05/router/errors.go#L31 みたいに自分でinterface実装すれば消えるけど、前やろうとしたらtemmaくんにいらないって言われた気もするからとりあえずなし