### PR TITLE
`assert` vs `require`

### DIFF
--- a/model/admin_impl_test.go
+++ b/model/admin_impl_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -16,7 +15,7 @@ func TestEntRepository_GetAdmins(t *testing.T) {
 	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_admins2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -35,20 +34,20 @@ func TestEntRepository_GetAdmins(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetAdmins(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := []*Admin{
 			{ID: user1.ID},
 			{ID: user2.ID},
 		}
-		assert.ElementsMatch(t, exp, got)
+		require.ElementsMatch(t, exp, got)
 	})
 
 	t.Run("Success2", func(t *testing.T) {
 		t.Parallel()
 
 		got, err := repo2.GetAdmins(ctx)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
@@ -68,11 +67,11 @@ func TestEntRepository_AddAdmins(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.AddAdmins(ctx, []uuid.UUID{user.ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		u, err := repo.GetUserByID(ctx, user.ID)
-		assert.NoError(t, err)
-		assert.True(t, u.Admin)
+		require.NoError(t, err)
+		require.True(t, u.Admin)
 	})
 }
 
@@ -92,10 +91,10 @@ func TestEntRepository_DeleteAdmins(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteAdmins(ctx, []uuid.UUID{user.ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		u, err := repo.GetUserByID(ctx, user.ID)
-		assert.NoError(t, err)
-		assert.False(t, u.Admin)
+		require.NoError(t, err)
+		require.False(t, u.Admin)
 	})
 }

--- a/model/comment_impl_test.go
+++ b/model/comment_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -18,7 +17,7 @@ func TestEntRepository_GetComments(t *testing.T) {
 	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_comments2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -43,7 +42,7 @@ func TestEntRepository_GetComments(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetComments(ctx, request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(l, r *Comment) bool {
@@ -70,14 +69,14 @@ func TestEntRepository_GetComments(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo2.GetComments(ctx, request.ID)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 
 	t.Run("UnknownRequest", func(t *testing.T) {
 		t.Parallel()
 		_, err := repo.GetComments(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -111,7 +110,7 @@ func TestEntRepository_CreateComment(t *testing.T) {
 			true)
 		require.NoError(t, err)
 		created, err := repo.CreateComment(ctx, comment, request.ID, user2.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(Comment{}, "ID"))
@@ -133,7 +132,7 @@ func TestEntRepository_CreateComment(t *testing.T) {
 			true)
 		require.NoError(t, err)
 		_, err = repo.CreateComment(ctx, random.AlphaNumeric(t, 30), uuid.New(), user.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownUser", func(t *testing.T) {
@@ -153,7 +152,7 @@ func TestEntRepository_CreateComment(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = repo.CreateComment(ctx, random.AlphaNumeric(t, 30), request.ID, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -183,7 +182,7 @@ func TestEntRepository_UpdateComment(t *testing.T) {
 
 		comment := random.AlphaNumeric(t, 30)
 		updated, err := repo.UpdateComment(ctx, comment, request.ID, created.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &Comment{
 			ID:        created.ID,
@@ -221,7 +220,7 @@ func TestEntRepository_UpdateComment(t *testing.T) {
 			nil, user.ID)
 		require.NoError(t, err)
 		updated, err := repo.UpdateComment(ctx, comment.Comment, request2.ID, comment.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &Comment{
 			ID:        comment.ID,
@@ -257,7 +256,7 @@ func TestEntRepository_UpdateComment(t *testing.T) {
 			ctx,
 			random.AlphaNumeric(t, 30),
 			request.ID, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownRequest", func(t *testing.T) {
@@ -279,7 +278,7 @@ func TestEntRepository_UpdateComment(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = repo.UpdateComment(ctx, random.AlphaNumeric(t, 30), uuid.New(), comment.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -308,11 +307,11 @@ func TestEntRepository_DeleteComment(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteComment(ctx, request.ID, comment.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		comments, err := repo.GetComments(ctx, request.ID)
 		require.NoError(t, err)
-		assert.Empty(t, comments)
+		require.Empty(t, comments)
 	})
 
 	t.Run("UnknownRequest", func(t *testing.T) {
@@ -334,7 +333,7 @@ func TestEntRepository_DeleteComment(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteComment(ctx, uuid.New(), comment.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownComment", func(t *testing.T) {
@@ -354,6 +353,6 @@ func TestEntRepository_DeleteComment(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteComment(ctx, request.ID, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/model/file_impl_test.go
+++ b/model/file_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -44,7 +43,7 @@ func TestEntRepository_CreateFile(t *testing.T) {
 		name := random.AlphaNumeric(t, 20)
 
 		file, err := repo.CreateFile(ctx, name, mimetype, request.ID, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(File{}, "ID"))
@@ -76,7 +75,7 @@ func TestEntRepository_CreateFile(t *testing.T) {
 		name := random.AlphaNumeric(t, 20)
 
 		_, err = repo.CreateFile(ctx, name, mimetype, request.ID, user.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("MissingName", func(t *testing.T) {
@@ -98,12 +97,12 @@ func TestEntRepository_CreateFile(t *testing.T) {
 			random.AlphaNumeric(t, 50),
 			tags, targets,
 			group, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mimetype := "image/png"
 
 		_, err = repo.CreateFile(ctx, "", mimetype, request.ID, user.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -132,16 +131,16 @@ func TestEntRepository_GetFile(t *testing.T) {
 			random.AlphaNumeric(t, 50),
 			tags, targets,
 			group, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mimetype := "image/png"
 
 		name := random.AlphaNumeric(t, 20)
 
 		file, err := repo.CreateFile(ctx, name, mimetype, request.ID, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		got, err := repo.GetFile(ctx, file.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &File{
 			ID:        file.ID,
@@ -158,7 +157,7 @@ func TestEntRepository_GetFile(t *testing.T) {
 		ctx := testutil.NewContext(t)
 
 		_, err = repo.GetFile(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -187,21 +186,21 @@ func TestEntRepository_DeleteFile(t *testing.T) {
 			random.AlphaNumeric(t, 50),
 			tags, targets,
 			group, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mimetype := "image/png"
 
 		name := random.AlphaNumeric(t, 20)
 
 		file, err := repo.CreateFile(ctx, name, mimetype, request.ID, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = repo.DeleteFile(ctx, file.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		r, err := repo.GetRequest(ctx, request.ID)
 		require.NoError(t, err)
-		assert.Empty(t, r.Files)
+		require.Empty(t, r.Files)
 	})
 
 	t.Run("UnknownFile", func(t *testing.T) {
@@ -209,6 +208,6 @@ func TestEntRepository_DeleteFile(t *testing.T) {
 		ctx := testutil.NewContext(t)
 
 		err = repo.DeleteFile(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/model/group_impl_test.go
+++ b/model/group_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -41,7 +40,7 @@ func TestEntRepository_GetGroups(t *testing.T) {
 		t.Parallel()
 		groups, err := repo2.GetGroups(ctx)
 		require.NoError(t, err)
-		assert.Empty(t, groups)
+		require.Empty(t, groups)
 	})
 }
 
@@ -62,7 +61,7 @@ func TestEntRepository_GetGroup(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetGroup(ctx, created.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, created, got, opts...)
 	})
@@ -70,7 +69,7 @@ func TestEntRepository_GetGroup(t *testing.T) {
 	t.Run("UnknownGroup", func(t *testing.T) {
 		t.Parallel()
 		_, err := repo.GetGroup(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -106,7 +105,7 @@ func TestEntRepository_CreateGroup(t *testing.T) {
 		name := random.AlphaNumeric(t, 20)
 		description := random.AlphaNumeric(t, 15)
 		created, err := repo.CreateGroup(ctx, name, description, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(Group{}, "ID"))
@@ -125,7 +124,7 @@ func TestEntRepository_CreateGroup(t *testing.T) {
 		t.Parallel()
 		budget := random.Numeric(t, 100000)
 		_, err := repo.CreateGroup(ctx, "", random.AlphaNumeric(t, 15), &budget)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -153,7 +152,7 @@ func TestEntRepository_UpdateGroup(t *testing.T) {
 			Budget:      &updatedBudget,
 		}
 		updated, err := repo.UpdateGroup(ctx, created.ID, ug.Name, ug.Description, ug.Budget)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &Group{
 			ID:          created.ID,
@@ -176,7 +175,7 @@ func TestEntRepository_UpdateGroup(t *testing.T) {
 			random.AlphaNumeric(t, 20),
 			random.AlphaNumeric(t, 15),
 			&budget)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("SuccessWithNilBudget", func(t *testing.T) {
@@ -196,7 +195,7 @@ func TestEntRepository_UpdateGroup(t *testing.T) {
 			Budget:      nil,
 		}
 		updated, err := repo.UpdateGroup(ctx, created.ID, ug.Name, ug.Description, ug.Budget)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &Group{
 			ID:          created.ID,
@@ -221,7 +220,7 @@ func TestEntRepository_UpdateGroup(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = repo.UpdateGroup(ctx, group.ID, "", random.AlphaNumeric(t, 15), &budget)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -242,17 +241,17 @@ func TestEntRepository_DeleteGroup(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteGroup(ctx, group.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		groups, err := repo.GetGroups(ctx)
 		require.NoError(t, err)
-		assert.Empty(t, groups)
+		require.Empty(t, groups)
 	})
 
 	t.Run("UnknownGroup", func(t *testing.T) {
 		t.Parallel()
 		err := repo.DeleteGroup(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -262,7 +261,7 @@ func TestEntRepository_GetMembers(t *testing.T) {
 	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_members2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -292,7 +291,7 @@ func TestEntRepository_GetMembers(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetMembers(ctx, group.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sortOpt := cmpopts.SortSlices(func(a, b *Member) bool {
 			return a.ID.ID() < b.ID.ID()
 		})
@@ -315,8 +314,8 @@ func TestEntRepository_GetMembers(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo2.GetMembers(ctx, group.ID)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
@@ -344,7 +343,7 @@ func TestEntRepository_CreateMember(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.AddMembers(ctx, group.ID, []uuid.UUID{user.ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := []*Member{{ID: user.ID}}
 		testutil.RequireEqual(t, exp, got)
 	})
@@ -361,7 +360,7 @@ func TestEntRepository_CreateMember(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = repo.AddMembers(ctx, group.ID, []uuid.UUID{uuid.New()})
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -391,7 +390,7 @@ func TestEntRepository_DeleteMember(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteMembers(ctx, group.ID, []uuid.UUID{member[0].ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -428,7 +427,7 @@ func TestEntRepository_GetOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetOwners(ctx, group.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sortOpt := cmpopts.SortSlices(func(a, b *Owner) bool {
 			return a.ID.ID() < b.ID.ID()
 		})
@@ -451,8 +450,8 @@ func TestEntRepository_GetOwners(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetOwners(ctx, group.ID)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
@@ -481,7 +480,7 @@ func TestEntRepository_CreateOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		owner, err := repo.AddOwners(ctx, group.ID, []uuid.UUID{user.ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := []*Owner{{ID: user.ID}}
 		testutil.RequireEqual(t, exp, owner)
 	})
@@ -498,7 +497,7 @@ func TestEntRepository_CreateOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = repo.AddOwners(ctx, group.ID, []uuid.UUID{uuid.New()})
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -528,6 +527,6 @@ func TestEntRepository_DeleteOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		err = repo.DeleteOwners(ctx, group.ID, []uuid.UUID{user.ID})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/model/request_impl_test.go
+++ b/model/request_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -114,7 +113,7 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo.GetRequests(ctx, RequestQuery{
 			Sort: &sort,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(a, b *RequestResponse) bool {
@@ -182,7 +181,7 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo2.GetRequests(ctx, RequestQuery{
 			Sort: &sort,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(a, b *RequestResponse) bool {
@@ -249,7 +248,7 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo3.GetRequests(ctx, RequestQuery{
 			Sort: &sort,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(a, b *RequestResponse) bool {
@@ -316,7 +315,7 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo4.GetRequests(ctx, RequestQuery{
 			Sort: &sort,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(a, b *RequestResponse) bool {
@@ -386,12 +385,12 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo5.GetRequests(ctx, RequestQuery{
 			Target: &target,
 		})
-		assert.NoError(t, err)
-		if assert.Len(t, got, 1) {
-			exp := request1.toExpectedRequestResponse(t)
-			opts := testutil.ApproxEqualOptions()
-			testutil.RequireEqual(t, exp, got[0], opts...)
-		}
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		exp := request1.toExpectedRequestResponse(t)
+		opts := testutil.ApproxEqualOptions()
+		testutil.RequireEqual(t, exp, got[0], opts...)
+
 	})
 
 	t.Run("SuccessWithQuerySince", func(t *testing.T) {
@@ -448,12 +447,12 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo6.GetRequests(ctx, RequestQuery{
 			Since: &since,
 		})
-		assert.NoError(t, err)
-		if assert.Len(t, got, 1) {
-			exp := request2.toExpectedRequestResponse(t)
-			opts := testutil.ApproxEqualOptions()
-			testutil.RequireEqual(t, exp, got[0], opts...)
-		}
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		exp := request2.toExpectedRequestResponse(t)
+		opts := testutil.ApproxEqualOptions()
+		testutil.RequireEqual(t, exp, got[0], opts...)
+
 	})
 
 	t.Run("SuccessWithQueryUntil", func(t *testing.T) {
@@ -510,13 +509,13 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo7.GetRequests(ctx, RequestQuery{
 			Until: &until,
 		})
-		assert.NoError(t, err)
-		if assert.Len(t, got, 1) {
-			exp := request1.toExpectedRequestResponse(t)
-			exp.Group.UpdatedAt = request2.Group.UpdatedAt
-			opts := testutil.ApproxEqualOptions()
-			testutil.RequireEqual(t, exp, got[0], opts...)
-		}
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		exp := request1.toExpectedRequestResponse(t)
+		exp.Group.UpdatedAt = request2.Group.UpdatedAt
+		opts := testutil.ApproxEqualOptions()
+		testutil.RequireEqual(t, exp, got[0], opts...)
+
 	})
 
 	t.Run("SuccessWithQueryStatus", func(t *testing.T) {
@@ -578,14 +577,14 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		got, err := repo8.GetRequests(ctx, RequestQuery{
 			Status: &status,
 		})
-		assert.NoError(t, err)
-		if assert.Len(t, got, 1) {
-			exp := request1.toExpectedRequestResponse(t)
-			exp.Status = Accepted
-			exp.Group.UpdatedAt = request2.Group.UpdatedAt
-			opts := testutil.ApproxEqualOptions()
-			testutil.RequireEqual(t, exp, got[0], opts...)
-		}
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		exp := request1.toExpectedRequestResponse(t)
+		exp.Status = Accepted
+		exp.Group.UpdatedAt = request2.Group.UpdatedAt
+		opts := testutil.ApproxEqualOptions()
+		testutil.RequireEqual(t, exp, got[0], opts...)
+
 	})
 
 	t.Run("SuccessWithQueryCreatedBy", func(t *testing.T) {
@@ -639,11 +638,10 @@ func TestEntRepository_GetRequests(t *testing.T) {
 			CreatedBy: &user1.ID,
 		})
 		require.NoError(t, err)
-		if assert.Len(t, got, 1) {
-			exp := request1.toExpectedRequestResponse(t)
-			opts := testutil.ApproxEqualOptions()
-			testutil.RequireEqual(t, exp, got[0], opts...)
-		}
+		require.Len(t, got, 1)
+		exp := request1.toExpectedRequestResponse(t)
+		opts := testutil.ApproxEqualOptions()
+		testutil.RequireEqual(t, exp, got[0], opts...)
 	})
 }
 
@@ -693,7 +691,7 @@ func TestEntRepository_CreateRequest(t *testing.T) {
 			title, content,
 			[]*Tag{tag}, []*RequestTarget{target},
 			group, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := &RequestDetail{
 			Status:  Submitted,
 			Title:   title,
@@ -741,7 +739,7 @@ func TestEntRepository_CreateRequest(t *testing.T) {
 			title, content,
 			[]*Tag{tag}, []*RequestTarget{},
 			group, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownTag", func(t *testing.T) {
@@ -777,7 +775,7 @@ func TestEntRepository_CreateRequest(t *testing.T) {
 			title, content,
 			[]*Tag{tag}, []*RequestTarget{},
 			group, user.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownGroup", func(t *testing.T) {
@@ -810,7 +808,7 @@ func TestEntRepository_CreateRequest(t *testing.T) {
 			title, content,
 			[]*Tag{tag}, []*RequestTarget{},
 			group, user.ID)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -854,7 +852,7 @@ func TestEntRepository_GetRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo.GetRequest(ctx, request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		testutil.AssertEqual(t, request, got, opts...)
 	})
@@ -863,7 +861,7 @@ func TestEntRepository_GetRequest(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.NewContext(t)
 		_, err := repo2.GetRequest(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
@@ -926,7 +924,7 @@ func TestEntRepository_UpdateRequest(t *testing.T) {
 			request.ID, request.Title, request.Content,
 			[]*Tag{tag}, []*RequestTarget{target},
 			group)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := &RequestDetail{
 			ID:        request.ID,
 			Status:    request.Status,
@@ -990,7 +988,7 @@ func TestEntRepository_UpdateRequest(t *testing.T) {
 			request.ID, title, request.Content,
 			[]*Tag{tag}, []*RequestTarget{target},
 			group)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := &RequestDetail{
 			ID:        request.ID,
 			Status:    request.Status,
@@ -1053,7 +1051,7 @@ func TestEntRepository_UpdateRequest(t *testing.T) {
 			request.ID, request.Title, content,
 			[]*Tag{tag}, []*RequestTarget{target},
 			group)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := &RequestDetail{
 			ID:        request.ID,
 			Status:    request.Status,
@@ -1117,7 +1115,7 @@ func TestEntRepository_UpdateRequest(t *testing.T) {
 			request.ID, request.Title, request.Content,
 			[]*Tag{unknownTag}, []*RequestTarget{target},
 			group)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownGroup", func(t *testing.T) {
@@ -1165,6 +1163,6 @@ func TestEntRepository_UpdateRequest(t *testing.T) {
 			request.ID, request.Title, request.Content,
 			[]*Tag{tag}, []*RequestTarget{target},
 			unknownGroup)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/model/request_impl_test.go
+++ b/model/request_impl_test.go
@@ -390,7 +390,6 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		exp := request1.toExpectedRequestResponse(t)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, exp, got[0], opts...)
-
 	})
 
 	t.Run("SuccessWithQuerySince", func(t *testing.T) {
@@ -452,7 +451,6 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		exp := request2.toExpectedRequestResponse(t)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, exp, got[0], opts...)
-
 	})
 
 	t.Run("SuccessWithQueryUntil", func(t *testing.T) {
@@ -515,7 +513,6 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		exp.Group.UpdatedAt = request2.Group.UpdatedAt
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, exp, got[0], opts...)
-
 	})
 
 	t.Run("SuccessWithQueryStatus", func(t *testing.T) {
@@ -584,7 +581,6 @@ func TestEntRepository_GetRequests(t *testing.T) {
 		exp.Group.UpdatedAt = request2.Group.UpdatedAt
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, exp, got[0], opts...)
-
 	})
 
 	t.Run("SuccessWithQueryCreatedBy", func(t *testing.T) {

--- a/model/request_status_impl_test.go
+++ b/model/request_status_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -36,7 +35,7 @@ func TestEntRepository_CreateStatus(t *testing.T) {
 
 		status := Status(random.Numeric(t, 5) + 1)
 		created, err := repo.CreateStatus(ctx, request.ID, user.ID, status)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(RequestStatus{}, "ID"))
@@ -66,7 +65,7 @@ func TestEntRepository_CreateStatus(t *testing.T) {
 
 		invalidStatus := Status(6)
 		_, err = repo.CreateStatus(ctx, request.ID, user.ID, invalidStatus)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownRequestID", func(t *testing.T) {
@@ -80,7 +79,7 @@ func TestEntRepository_CreateStatus(t *testing.T) {
 
 		status := Status(random.Numeric(t, 5) + 1)
 		_, err = repo.CreateStatus(ctx, uuid.New(), user.ID, status)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 
 	t.Run("UnknownUserID", func(t *testing.T) {
@@ -101,6 +100,6 @@ func TestEntRepository_CreateStatus(t *testing.T) {
 
 		status := Status(random.Numeric(t, 5) + 1)
 		_, err = repo.CreateStatus(ctx, request.ID, uuid.New(), status)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/model/request_target_impl_test.go
+++ b/model/request_target_impl_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -56,7 +55,7 @@ func TestEntRepository_GetRequestTargets(t *testing.T) {
 			{Target: target2.Target, Amount: target2.Amount, CreatedAt: time.Now()},
 		}
 		got, err := repo.GetRequestTargets(ctx, request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(RequestTargetDetail{}, "ID", "PaidAt"),
@@ -83,8 +82,8 @@ func TestEntRepository_GetRequestTargets(t *testing.T) {
 			nil, user.ID)
 		require.NoError(t, err)
 		got, err := repo2.GetRequestTargets(ctx, request.ID)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
@@ -123,7 +122,7 @@ func TestEntRepository_createRequestTargets(t *testing.T) {
 			random.AlphaNumeric(t, 40),
 			nil, []*RequestTarget{target1, target2},
 			nil, user1.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		exp := []*RequestTargetDetail{
 			{Target: target1.Target, Amount: target1.Amount, CreatedAt: time.Now()},
 			{Target: target2.Target, Amount: target2.Amount, CreatedAt: time.Now()},
@@ -184,10 +183,10 @@ func TestEntRepository_deleteRequestTargets(t *testing.T) {
 			random.AlphaNumeric(t, 40),
 			nil, []*RequestTarget{},
 			nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		got, err := repo.GetRequestTargets(ctx, request.ID)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 
 	t.Run("Success2", func(t *testing.T) {
@@ -227,9 +226,9 @@ func TestEntRepository_deleteRequestTargets(t *testing.T) {
 			random.AlphaNumeric(t, 40),
 			nil, []*RequestTarget{target1, target2},
 			nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		got, err := repo2.GetRequestTargets(ctx, request.ID)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 	})
 }

--- a/model/tag_impl_test.go
+++ b/model/tag_impl_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
 )
@@ -14,10 +14,10 @@ import (
 func TestEntRepository_GetTags(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "get_tags")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_tags2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -26,7 +26,7 @@ func TestEntRepository_GetTags(t *testing.T) {
 		tag2, _ := repo.CreateTag(ctx, random.AlphaNumeric(t, 20))
 
 		got, err := repo.GetTags(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(l, r *Tag) bool {
@@ -39,15 +39,15 @@ func TestEntRepository_GetTags(t *testing.T) {
 	t.Run("Success2", func(t *testing.T) {
 		t.Parallel()
 		got, err := repo2.GetTags(ctx)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
 func TestEntRepository_CreateTag(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "create_tag")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 
 	t.Run("Success", func(t *testing.T) {
@@ -55,7 +55,7 @@ func TestEntRepository_CreateTag(t *testing.T) {
 		name := random.AlphaNumeric(t, 20)
 		tag, err := repo.CreateTag(ctx, name)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(Tag{}, "ID"))
@@ -73,26 +73,26 @@ func TestEntRepository_CreateTag(t *testing.T) {
 		name := ""
 		_, err := repo.CreateTag(ctx, name)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestEntRepository_UpdateTag(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "update_tag")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 
 	t.Run("Success1", func(t *testing.T) {
 		t.Parallel()
 		created, err := repo.CreateTag(ctx, random.AlphaNumeric(t, 20))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		name := random.AlphaNumeric(t, 20)
 
 		updated, err := repo.UpdateTag(ctx, created.ID, name)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &Tag{
 			ID:        created.ID,
@@ -107,11 +107,11 @@ func TestEntRepository_UpdateTag(t *testing.T) {
 	t.Run("Success2", func(t *testing.T) {
 		t.Parallel()
 		tag, err := repo.CreateTag(ctx, random.AlphaNumeric(t, 20))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		updated, err := repo.UpdateTag(ctx, tag.ID, tag.Name)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, tag, updated, opts...)
 	})
@@ -119,34 +119,34 @@ func TestEntRepository_UpdateTag(t *testing.T) {
 	t.Run("MissingName", func(t *testing.T) {
 		t.Parallel()
 		tag, err := repo.CreateTag(ctx, random.AlphaNumeric(t, 20))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		name := ""
 		_, err = repo.UpdateTag(ctx, tag.ID, name)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestEntRepository_DeleteTag(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "delete_tag")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
 		name := random.AlphaNumeric(t, 20)
 		tag, err := repo.CreateTag(ctx, name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = repo.DeleteTag(ctx, tag.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("UnknownTag", func(t *testing.T) {
 		t.Parallel()
 		err = repo.DeleteTag(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/model/transaction_detail_impl_test.go
+++ b/model/transaction_detail_impl_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -33,9 +32,9 @@ func TestEntRepository_createTransactionDetail(t *testing.T) {
 		amount := random.Numeric(t, 100000)
 		target := random.AlphaNumeric(t, 10)
 		td, err := repo.createTransactionDetail(ctx, tx, title, amount, target)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = tx.Commit()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.IgnoreFields(TransactionDetail{}, "ID"))
@@ -83,9 +82,9 @@ func TestEntRepository_updateTransactionDetail(t *testing.T) {
 		td, err := repo.updateTransactionDetail(
 			ctx, tx, trns.ID,
 			updateTitle, updatedAmount, updatedTarget)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		err = tx.Commit()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &TransactionDetail{
 			ID:        td.ID,

--- a/model/transaction_impl_test.go
+++ b/model/transaction_impl_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
@@ -83,8 +82,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 			Sort: &sort,
 		}
 		got, err := repo.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx2, tx1}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -125,8 +124,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 			Sort: &sort,
 		}
 		got, err := repo2.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx1, tx2}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -166,8 +165,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 			Sort: &sort,
 		}
 		got, err := repo3.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx1, tx2}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -214,8 +213,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		}
 		// nolint:contextcheck
 		got, err := repo4.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx2, tx1}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -256,8 +255,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 			Sort: &sort,
 		}
 		got, err := repo5.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx2, tx1}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -297,8 +296,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 			Target: &target1,
 		}
 		got, err := repo6.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -343,8 +342,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo7.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -390,8 +389,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo8.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -439,8 +438,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo9.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -481,8 +480,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		require.NoError(t, err)
 
 		got, err := repo10.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Len(t, got, 1)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
 		opts := testutil.ApproxEqualOptions()
 		exp := []*TransactionResponse{tx}
 		testutil.RequireEqual(t, exp, got, opts...)
@@ -494,8 +493,8 @@ func TestEntRepository_GetTransactions(t *testing.T) {
 		// Get Transactions
 		query := TransactionQuery{}
 		got, err := repo11.GetTransactions(ctx, query)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 }
 
@@ -533,8 +532,8 @@ func TestEntRepository_GetTransaction(t *testing.T) {
 
 		// Get Transaction
 		got, err := repo.GetTransaction(ctx, tx.ID)
-		assert.NoError(t, err)
-		assert.NotNil(t, got)
+		require.NoError(t, err)
+		require.NotNil(t, got)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, tx, got, opts...)
 	})
@@ -587,7 +586,7 @@ func TestEntRepository_CreateTransaction(t *testing.T) {
 			ctx,
 			title, amount, target,
 			[]*uuid.UUID{&tag.ID}, &group.ID, &request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,
@@ -639,7 +638,7 @@ func TestEntRepository_CreateTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		tx, err := repo.CreateTransaction(ctx, title, amount, target, nil, &group.ID, &request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,
@@ -690,7 +689,7 @@ func TestEntRepository_CreateTransaction(t *testing.T) {
 			ctx,
 			title, amount, target,
 			[]*uuid.UUID{&tag.ID}, nil, &request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,
@@ -718,7 +717,7 @@ func TestEntRepository_CreateTransaction(t *testing.T) {
 		target := random.AlphaNumeric(t, 20)
 
 		tx, err := repo.CreateTransaction(ctx, title, amount, target, nil, nil, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,
@@ -746,7 +745,7 @@ func TestEntRepository_CreateTransaction(t *testing.T) {
 		target := random.AlphaNumeric(t, 20)
 
 		tx, err := repo.CreateTransaction(ctx, title, amount, target, nil, nil, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,
@@ -843,7 +842,7 @@ func TestEntRepository_UpdateTransaction(t *testing.T) {
 			ctx,
 			tx.ID, title, amount, target,
 			[]*uuid.UUID{&tag.ID}, &group.ID, &request.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #831
 		opts = append(opts,

--- a/model/user_impl_test.go
+++ b/model/user_impl_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/testutil"
 	"github.com/traPtitech/Jomon/testutil/random"
 )
@@ -14,10 +14,10 @@ import (
 func TestEntRepository_GetUsers(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "get_user")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_user2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -25,8 +25,8 @@ func TestEntRepository_GetUsers(t *testing.T) {
 		ctx := testutil.NewContext(t)
 
 		got, err := repo.GetUsers(ctx)
-		assert.NoError(t, err)
-		assert.Empty(t, got)
+		require.NoError(t, err)
+		require.Empty(t, got)
 	})
 
 	t.Run("Success2", func(t *testing.T) {
@@ -34,13 +34,13 @@ func TestEntRepository_GetUsers(t *testing.T) {
 		ctx := testutil.NewContext(t)
 
 		user1, err := repo2.CreateUser(ctx, "user1", "user1", true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		user2, err := repo2.CreateUser(ctx, "user2", "user2", true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		got, err := repo2.GetUsers(ctx)
-		assert.NoError(t, err)
-		assert.Len(t, got, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts,
 			cmpopts.SortSlices(func(l, r *User) bool {
@@ -54,7 +54,7 @@ func TestEntRepository_GetUsers(t *testing.T) {
 func TestEntRepository_CreateUser(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "create_user")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 
 	t.Run("Success", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestEntRepository_CreateUser(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		user, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		opts = append(opts, cmpopts.IgnoreFields(User{}, "ID"))
 		exp := &User{
@@ -89,17 +89,17 @@ func TestEntRepository_CreateUser(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		_, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestEntRepository_GetUserByName(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "get_user_by_name")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_user_by_name2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -110,10 +110,10 @@ func TestEntRepository_GetUserByName(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		user, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		got, err := repo.GetUserByName(ctx, name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, user, got, opts...)
 	})
@@ -122,17 +122,17 @@ func TestEntRepository_GetUserByName(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.NewContext(t)
 		_, err = repo2.GetUserByName(ctx, random.AlphaNumeric(t, 20))
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestEntRepository_GetUserByID(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "get_user_by_id")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 	client2, storage2, err := setup(t, ctx, "get_user_by_id2")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo2 := NewEntRepository(client2, storage2)
 
 	t.Run("Success", func(t *testing.T) {
@@ -143,10 +143,10 @@ func TestEntRepository_GetUserByID(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		user, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		got, err := repo.GetUserByID(ctx, user.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		testutil.RequireEqual(t, user, got, opts...)
 	})
@@ -155,14 +155,14 @@ func TestEntRepository_GetUserByID(t *testing.T) {
 		t.Parallel()
 		ctx := testutil.NewContext(t)
 		_, err := repo2.GetUserByID(ctx, uuid.New())
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }
 
 func TestEntRepository_UpdateUser(t *testing.T) {
 	ctx := testutil.NewContext(t)
 	client, storage, err := setup(t, ctx, "update_user")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	repo := NewEntRepository(client, storage)
 
 	t.Run("Success", func(t *testing.T) {
@@ -174,13 +174,13 @@ func TestEntRepository_UpdateUser(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		user, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		uname := random.AlphaNumeric(t, 20)
 		udn := random.AlphaNumeric(t, 20)
 		uadmin := random.Numeric(t, 2) == 1
 		got, err := repo.UpdateUser(ctx, user.ID, uname, udn, uadmin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := &User{
 			ID:          user.ID,
@@ -202,12 +202,12 @@ func TestEntRepository_UpdateUser(t *testing.T) {
 		admin := random.Numeric(t, 2) == 1
 
 		user, err := repo.CreateUser(ctx, name, dn, admin)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		uname := ""
 		udn := random.AlphaNumeric(t, 20)
 		uadmin := random.Numeric(t, 2) == 1
 		_, err = repo.UpdateUser(ctx, user.ID, uname, udn, uadmin)
-		assert.Error(t, err)
+		require.Error(t, err)
 	})
 }

--- a/router/admin_test.go
+++ b/router/admin_test.go
@@ -41,7 +41,7 @@ func TestHandler_GetAdmins(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			GetAdmins(c.Request().Context()).
@@ -70,7 +70,7 @@ func TestHandler_GetAdmins(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			GetAdmins(c.Request().Context()).
@@ -100,7 +100,7 @@ func TestHandler_GetAdmins(t *testing.T) {
 		resErr := errors.New("failed to get admins")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			GetAdmins(c.Request().Context()).
@@ -133,7 +133,7 @@ func TestHandler_PostAdmin(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			AddAdmins(c.Request().Context(), admins).
@@ -163,7 +163,7 @@ func TestHandler_PostAdmin(t *testing.T) {
 		resErr := errors.New("failed to create admin")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			AddAdmins(c.Request().Context(), admins).
@@ -196,7 +196,7 @@ func TestHandler_PostAdmin(t *testing.T) {
 		errors.As(errors.New("failed to create admin"), &resErr)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			AddAdmins(c.Request().Context(), admins).
@@ -230,7 +230,7 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			DeleteAdmins(c.Request().Context(), admins).
@@ -260,7 +260,7 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 		resErr := errors.New("failed to delete admin")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			DeleteAdmins(c.Request().Context(), admins).
@@ -289,9 +289,10 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = h.Handlers.DeleteAdmins(c)
+
 		assert.Error(t, err)
 		// FIXME: http.StatusBadRequestの判定をしたい
 	})
@@ -317,7 +318,7 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 		errors.As(errors.New("failed to delete admin"), &resErr)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockAdminRepository.
 			EXPECT().
 			DeleteAdmins(c.Request().Context(), admins).

--- a/router/admin_test.go
+++ b/router/admin_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/ent"
 	"github.com/traPtitech/Jomon/model"
@@ -49,7 +48,7 @@ func TestHandler_GetAdmins(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.NoError(t, h.Handlers.GetAdmins(c))
+		require.NoError(t, h.Handlers.GetAdmins(c))
 		testutil.AssertEqual(t, http.StatusOK, rec.Code)
 		var res []uuid.UUID
 		err = json.Unmarshal(rec.Body.Bytes(), &res)
@@ -78,12 +77,12 @@ func TestHandler_GetAdmins(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.NoError(t, h.Handlers.GetAdmins(c))
+		require.NoError(t, h.Handlers.GetAdmins(c))
 		testutil.AssertEqual(t, http.StatusOK, rec.Code)
 		var res []uuid.UUID
 		err = json.Unmarshal(rec.Body.Bytes(), &res)
 		require.NoError(t, err)
-		assert.Empty(t, res)
+		require.Empty(t, res)
 	})
 
 	t.Run("FailedWithError", func(t *testing.T) {
@@ -108,7 +107,7 @@ func TestHandler_GetAdmins(t *testing.T) {
 
 		err = h.Handlers.GetAdmins(c)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -139,8 +138,8 @@ func TestHandler_PostAdmin(t *testing.T) {
 			AddAdmins(c.Request().Context(), admins).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.PostAdmins(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostAdmins(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedWithError", func(t *testing.T) {
@@ -170,9 +169,9 @@ func TestHandler_PostAdmin(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.PostAdmins(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("FailedWithEntConstraintError", func(t *testing.T) {
@@ -203,9 +202,9 @@ func TestHandler_PostAdmin(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.PostAdmins(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -236,8 +235,8 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 			DeleteAdmins(c.Request().Context(), admins).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteAdmins(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteAdmins(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedWithError", func(t *testing.T) {
@@ -267,9 +266,9 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteAdmins(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("InvalidAdminID", func(t *testing.T) {
@@ -293,7 +292,7 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 
 		err = h.Handlers.DeleteAdmins(c)
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestの判定をしたい
 	})
 
@@ -325,7 +324,7 @@ func TestHandler_DeleteAdmin(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteAdmins(c)
-		assert.Error(t, err)
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Error(t, err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }

--- a/router/auth_test.go
+++ b/router/auth_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Sample verifier and challenge comes from Appendix B of RFC7636
@@ -19,5 +19,5 @@ func TestHandler_GetCodeChallenge(t *testing.T) {
 		WithPadding(base64.NoPadding)
 	challenge := encoder.EncodeToString(codeVerifierHash[:])
 
-	assert.Equal(t, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", challenge)
+	require.Equal(t, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", challenge)
 }

--- a/router/file_test.go
+++ b/router/file_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/model"
 	"github.com/traPtitech/Jomon/testutil"
@@ -50,21 +49,21 @@ func TestHandlers_PostFile(t *testing.T) {
 		go func() {
 			defer func() {
 				err := writer.Close()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}()
 			err := writer.WriteField("name", "test")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = writer.WriteField("request_id", request.String())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			part := make(textproto.MIMEHeader)
 			part.Set("Content-Type", "image/jpeg")
 			part.Set("Content-Disposition", `form-data; name="file"; filename="test.jpg"`)
 			pw, err := writer.CreatePart(part)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			file, err := base64.RawStdEncoding.DecodeString(testJpeg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = pw.Write(file)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}()
 
 		file := &model.File{
@@ -100,8 +99,8 @@ func TestHandlers_PostFile(t *testing.T) {
 			Save(file.ID.String(), gomock.Any()).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.PostFile(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostFile(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedToRepositoryCreateFile", func(t *testing.T) {
@@ -122,21 +121,21 @@ func TestHandlers_PostFile(t *testing.T) {
 		go func() {
 			defer func() {
 				err := writer.Close()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}()
 			err := writer.WriteField("name", "test")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = writer.WriteField("request_id", request.String())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			part := make(textproto.MIMEHeader)
 			part.Set("Content-Type", "image/jpeg")
 			part.Set("Content-Disposition", `form-data; name="file"; filename="test.jpg"`)
 			pw, err := writer.CreatePart(part)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			file, err := base64.RawStdEncoding.DecodeString(testJpeg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = pw.Write(file)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}()
 
 		e := echo.New()
@@ -160,16 +159,16 @@ func TestHandlers_PostFile(t *testing.T) {
 
 		mocErr := errors.New("failed to create file")
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			CreateFile(c.Request().Context(), "test", "image/jpeg", request, user.ID).
 			Return(nil, mocErr)
 
 		err = h.Handlers.PostFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("FailedToServiceCreateFile", func(t *testing.T) {
@@ -190,21 +189,21 @@ func TestHandlers_PostFile(t *testing.T) {
 		go func() {
 			defer func() {
 				err := writer.Close()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}()
 			err := writer.WriteField("name", "test")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = writer.WriteField("request_id", request.String())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			part := make(textproto.MIMEHeader)
 			part.Set("Content-Type", "image/jpeg")
 			part.Set("Content-Disposition", `form-data; name="file"; filename="test.jpg"`)
 			pw, err := writer.CreatePart(part)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			file, err := base64.RawStdEncoding.DecodeString(testJpeg)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = pw.Write(file)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}()
 
 		file := &model.File{
@@ -243,9 +242,9 @@ func TestHandlers_PostFile(t *testing.T) {
 			Return(mocErr)
 
 		err = h.Handlers.PostFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 }
 
@@ -279,7 +278,7 @@ func TestHandlers_GetFile(t *testing.T) {
 		c.SetParamValues(file.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			GetFile(c.Request().Context(), file.ID).
@@ -290,8 +289,8 @@ func TestHandlers_GetFile(t *testing.T) {
 			Open(file.ID.String()).
 			Return(r, nil)
 
-		assert.NoError(t, h.Handlers.GetFile(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetFile(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedToGetFile", func(t *testing.T) {
@@ -319,16 +318,16 @@ func TestHandlers_GetFile(t *testing.T) {
 		mocErr := errors.New("file not found")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			GetFile(c.Request().Context(), file.ID).
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("FailedToOpenFile", func(t *testing.T) {
@@ -354,7 +353,7 @@ func TestHandlers_GetFile(t *testing.T) {
 		c.SetParamValues(file.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			GetFile(c.Request().Context(), file.ID).
@@ -368,9 +367,9 @@ func TestHandlers_GetFile(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("UnknownFile", func(t *testing.T) {
@@ -388,14 +387,14 @@ func TestHandlers_GetFile(t *testing.T) {
 		c.SetParamValues("po")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, mocErr := uuid.Parse("po")
 
 		err = h.Handlers.GetFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
 	})
 }
 
@@ -426,14 +425,14 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 		c.SetParamValues(file.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			GetFile(c.Request().Context(), file.ID).
 			Return(file, nil)
 
-		assert.NoError(t, h.Handlers.GetFileMeta(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetFileMeta(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var res *FileMetaResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &res)
 		require.NoError(t, err)
@@ -473,16 +472,16 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 		mocErr := errors.New("file not found")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			GetFile(c.Request().Context(), file.ID).
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetFileMeta(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("UnknownFile", func(t *testing.T) {
@@ -500,14 +499,14 @@ func TestHandlers_GetFileMeta(t *testing.T) {
 		c.SetParamValues("po")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, mocErr := uuid.Parse("po")
 
 		err = h.Handlers.GetFileMeta(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
 	})
 }
 
@@ -537,7 +536,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 		c.SetParamValues(file.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			DeleteFile(c.Request().Context(), file.ID).
@@ -548,8 +547,8 @@ func TestHandlers_DeleteFile(t *testing.T) {
 			Delete(file.ID.String()).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteFile(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteFile(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedToRepositoryDeleteFile", func(t *testing.T) {
@@ -577,16 +576,16 @@ func TestHandlers_DeleteFile(t *testing.T) {
 		mocErr := errors.New("file could not be deleted")
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			DeleteFile(c.Request().Context(), file.ID).
 			Return(mocErr)
 
 		err = h.Handlers.DeleteFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("FailedToServiceDeleteFile", func(t *testing.T) {
@@ -611,7 +610,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 		c.SetParamValues(file.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockFileRepository.
 			EXPECT().
 			DeleteFile(c.Request().Context(), file.ID).
@@ -625,9 +624,9 @@ func TestHandlers_DeleteFile(t *testing.T) {
 			Return(mocErr)
 
 		err = h.Handlers.DeleteFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("UnknownFile", func(t *testing.T) {
@@ -649,11 +648,11 @@ func TestHandlers_DeleteFile(t *testing.T) {
 		c.SetParamValues(invalidUUID)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = h.Handlers.DeleteFile(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
 	})
 }

--- a/router/group_test.go
+++ b/router/group_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/ent"
 	"github.com/traPtitech/Jomon/model"
@@ -58,14 +57,14 @@ func TestHandlers_GetGroups(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroups(c.Request().Context()).
 			Return(groups, nil)
 
-		assert.NoError(t, h.Handlers.GetGroups(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetGroups(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*GroupOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -97,14 +96,14 @@ func TestHandlers_GetGroups(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroups(c.Request().Context()).
 			Return(groups, nil)
 
-		assert.NoError(t, h.Handlers.GetGroups(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetGroups(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*GroupOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -125,7 +124,7 @@ func TestHandlers_GetGroups(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		resErr := errors.New("failed to get groups")
 		h.Repository.MockGroupRepository.
 			EXPECT().
@@ -133,9 +132,9 @@ func TestHandlers_GetGroups(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.GetGroups(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -183,8 +182,8 @@ func TestHandlers_PostGroup(t *testing.T) {
 			CreateGroup(c.Request().Context(), group.Name, group.Description, group.Budget).
 			Return(group, nil)
 
-		assert.NoError(t, h.Handlers.PostGroup(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostGroup(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got GroupOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -234,9 +233,9 @@ func TestHandlers_PostGroup(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostGroup(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -313,7 +312,7 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(group.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
@@ -328,8 +327,8 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 			Return(members, nil)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got GroupDetail
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -375,7 +374,7 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(group.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
@@ -390,8 +389,8 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 			Return([]*model.Member{}, nil)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got GroupDetail
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -429,9 +428,9 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		h, err := NewTestHandlers(t, ctrl)
 		require.NoError(t, err)
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilGroupID", func(t *testing.T) {
@@ -450,14 +449,14 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(uuid.Nil.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -479,16 +478,16 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(unknownGroupID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), unknownGroupID).
 			Return(nil, resErr)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("FailedToGetGroup", func(t *testing.T) {
@@ -520,16 +519,16 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(group.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
 			Return(nil, resErr)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("FailedToGetOwners", func(t *testing.T) {
@@ -561,7 +560,7 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(group.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
@@ -573,9 +572,9 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("FailedToGetMembers", func(t *testing.T) {
@@ -618,7 +617,7 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 		c.SetParamValues(group.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
@@ -635,9 +634,9 @@ func TestHandlers_GetGroupDetail(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.GetGroupDetail(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -700,8 +699,8 @@ func TestHandlers_PutGroup(t *testing.T) {
 				group.ID, updated.Name,
 				updated.Description, updated.Budget).
 			Return(updated, nil)
-		assert.NoError(t, h.Handlers.PutGroup(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutGroup(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got GroupOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -775,9 +774,9 @@ func TestHandlers_PutGroup(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PutGroup(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("FailedWithUUID", func(t *testing.T) {
@@ -812,9 +811,9 @@ func TestHandlers_PutGroup(t *testing.T) {
 		h, err := NewTestHandlers(t, ctrl)
 		require.NoError(t, err)
 		err = h.Handlers.PutGroup(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -853,8 +852,8 @@ func TestHandlers_DeleteGroup(t *testing.T) {
 			DeleteGroup(c.Request().Context(), group.ID).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteGroup(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteGroup(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("FailedWithDeleteGroup", func(t *testing.T) {
@@ -891,9 +890,9 @@ func TestHandlers_DeleteGroup(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteGroup(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("FailedWithUUID", func(t *testing.T) {
@@ -916,9 +915,9 @@ func TestHandlers_DeleteGroup(t *testing.T) {
 		h, err := NewTestHandlers(t, ctrl)
 		require.NoError(t, err)
 		err = h.Handlers.DeleteGroup(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -975,8 +974,8 @@ func TestHandlers_PostMember(t *testing.T) {
 			}, nil)
 
 		require.NoError(t, err)
-		assert.NoError(t, h.Handlers.PostMember(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostMember(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []uuid.UUID
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1009,9 +1008,9 @@ func TestHandlers_PostMember(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.PostMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -1039,9 +1038,9 @@ func TestHandlers_PostMember(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.PostMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -1084,9 +1083,9 @@ func TestHandlers_PostMember(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("UnknownUserID", func(t *testing.T) {
@@ -1131,9 +1130,9 @@ func TestHandlers_PostMember(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -1185,8 +1184,8 @@ func TestHandlers_DeleteMember(t *testing.T) {
 			DeleteMembers(c.Request().Context(), group.ID, []uuid.UUID{user.ID}).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteMember(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteMember(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("NilGroupUUID", func(t *testing.T) {
@@ -1224,9 +1223,9 @@ func TestHandlers_DeleteMember(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.DeleteMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -1269,9 +1268,9 @@ func TestHandlers_DeleteMember(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("UnknownMemberID", func(t *testing.T) {
@@ -1315,9 +1314,9 @@ func TestHandlers_DeleteMember(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 
 	t.Run("InvalidGroupUUID", func(t *testing.T) {
@@ -1346,9 +1345,9 @@ func TestHandlers_DeleteMember(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.DeleteMember(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -1404,8 +1403,8 @@ func TestHandlers_PostOwner(t *testing.T) {
 				modelOwner,
 			}, nil)
 
-		assert.NoError(t, h.Handlers.PostOwner(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostOwner(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []uuid.UUID
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1438,9 +1437,9 @@ func TestHandlers_PostOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.PostOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -1468,9 +1467,9 @@ func TestHandlers_PostOwner(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.PostOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -1512,9 +1511,9 @@ func TestHandlers_PostOwner(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownUserID", func(t *testing.T) {
@@ -1557,9 +1556,9 @@ func TestHandlers_PostOwner(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -1611,8 +1610,8 @@ func TestHandlers_DeleteOwner(t *testing.T) {
 			DeleteOwners(c.Request().Context(), group.ID, []uuid.UUID{user.ID}).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteOwner(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteOwner(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("NilGroupUUID", func(t *testing.T) {
@@ -1641,9 +1640,9 @@ func TestHandlers_DeleteOwner(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.DeleteOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -1686,8 +1685,8 @@ func TestHandlers_DeleteOwner(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteOwner(c)
-		assert.Error(t, err)
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Error(t, err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("UnknownOwnerID", func(t *testing.T) {
@@ -1730,9 +1729,9 @@ func TestHandlers_DeleteOwner(t *testing.T) {
 			Return(resErr)
 
 		err = h.Handlers.DeleteOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("InvalidGroupUUID", func(t *testing.T) {
@@ -1761,8 +1760,8 @@ func TestHandlers_DeleteOwner(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.DeleteOwner(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }

--- a/router/request_test.go
+++ b/router/request_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/ent"
 	"github.com/traPtitech/Jomon/model"
@@ -157,8 +156,8 @@ func TestHandlers_GetRequests(t *testing.T) {
 			}).
 			Return(requests, nil)
 
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -206,7 +205,7 @@ func TestHandlers_GetRequests(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockRequestRepository.
 			EXPECT().
 			GetRequests(c.Request().Context(), model.RequestQuery{
@@ -215,12 +214,12 @@ func TestHandlers_GetRequests(t *testing.T) {
 			}).
 			Return(requests, nil)
 
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
-		assert.Empty(t, got)
+		require.Empty(t, got)
 	})
 
 	t.Run("Success3", func(t *testing.T) {
@@ -263,8 +262,8 @@ func TestHandlers_GetRequests(t *testing.T) {
 			}).
 			Return(requests, nil)
 
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -328,8 +327,8 @@ func TestHandlers_GetRequests(t *testing.T) {
 			}).
 			Return(requests, nil)
 
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -392,8 +391,8 @@ func TestHandlers_GetRequests(t *testing.T) {
 				Offset: 0,
 			}).
 			Return(requests, nil)
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -465,8 +464,8 @@ func TestHandlers_GetRequests(t *testing.T) {
 				Offset: 0,
 			}).
 			Return(requests, nil)
-		assert.NoError(t, h.Handlers.GetRequests(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequests(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -527,9 +526,7 @@ func TestHandlers_GetRequests(t *testing.T) {
 			Return(modelRequests, nil)
 
 		err = h.Handlers.GetRequests(c)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*RequestResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
@@ -568,9 +565,9 @@ func TestHandlers_GetRequests(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.GetRequests(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, "invalid status"), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, "invalid status"), err)
 	})
 
 	t.Run("FailedToGetRequests", func(t *testing.T) {
@@ -585,7 +582,7 @@ func TestHandlers_GetRequests(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		resErr := errors.New("Failed to get requests.")
 		h.Repository.MockRequestRepository.
 			EXPECT().
@@ -596,9 +593,9 @@ func TestHandlers_GetRequests(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.GetRequests(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }
 
@@ -660,8 +657,8 @@ func TestHandlers_PostRequest(t *testing.T) {
 				group, reqRequest.CreatedBy).
 			Return(request, nil)
 
-		assert.NoError(t, h.Handlers.PostRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -736,8 +733,8 @@ func TestHandlers_PostRequest(t *testing.T) {
 				group, reqRequest.CreatedBy).
 			Return(request, nil)
 
-		assert.NoError(t, h.Handlers.PostRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -812,8 +809,8 @@ func TestHandlers_PostRequest(t *testing.T) {
 				group, reqRequest.CreatedBy).
 			Return(request, nil)
 
-		assert.NoError(t, h.Handlers.PostRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -891,8 +888,8 @@ func TestHandlers_PostRequest(t *testing.T) {
 				group, reqRequest.CreatedBy).
 			Return(request, nil)
 
-		assert.NoError(t, h.Handlers.PostRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -944,9 +941,9 @@ func TestHandlers_PostRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -992,9 +989,9 @@ func TestHandlers_PostRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("UnknownUserID", func(t *testing.T) {
@@ -1045,9 +1042,9 @@ func TestHandlers_PostRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PostRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 }
 
@@ -1102,8 +1099,8 @@ func TestHandlers_GetRequest(t *testing.T) {
 			GetComments(c.Request().Context(), request.ID).
 			Return(nil, nil)
 
-		assert.NoError(t, h.Handlers.GetRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1175,8 +1172,8 @@ func TestHandlers_GetRequest(t *testing.T) {
 			GetComments(c.Request().Context(), request.ID).
 			Return(comments, nil)
 
-		assert.NoError(t, h.Handlers.GetRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1242,8 +1239,8 @@ func TestHandlers_GetRequest(t *testing.T) {
 			EXPECT().
 			GetComments(c.Request().Context(), request.ID).
 			Return(nil, nil)
-		assert.NoError(t, h.Handlers.GetRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1277,9 +1274,9 @@ func TestHandlers_GetRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.GetRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -1303,9 +1300,9 @@ func TestHandlers_GetRequest(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.GetRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownID", func(t *testing.T) {
@@ -1336,9 +1333,9 @@ func TestHandlers_GetRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.GetRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 }
 
@@ -1417,7 +1414,7 @@ func TestHandlers_PutRequest(t *testing.T) {
 			},
 		)
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockRequestRepository.
 			EXPECT().
 			UpdateRequest(
@@ -1428,8 +1425,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 				group).
 			Return(updateRequest, nil)
 
-		assert.NoError(t, h.Handlers.PutRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1523,7 +1520,7 @@ func TestHandlers_PutRequest(t *testing.T) {
 		c.SetParamValues(request.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		h.Repository.MockTagRepository.
 			EXPECT().
@@ -1543,8 +1540,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 				group).
 			Return(updateRequest, nil)
 
-		assert.NoError(t, h.Handlers.PutRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1644,7 +1641,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 			},
 		)
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		h.Repository.MockRequestRepository.
 			EXPECT().
 			UpdateRequest(
@@ -1655,8 +1653,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 				group).
 			Return(updateRequest, nil)
 
-		assert.NoError(t, h.Handlers.PutRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1746,7 +1744,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 			},
 		)
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		h.Repository.MockGroupRepository.
 			EXPECT().
 			GetGroup(c.Request().Context(), group.ID).
@@ -1761,8 +1760,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 				group).
 			Return(updateRequest, nil)
 
-		assert.NoError(t, h.Handlers.PutRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1859,7 +1858,7 @@ func TestHandlers_PutRequest(t *testing.T) {
 			},
 		)
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockRequestRepository.
 			EXPECT().
 			UpdateRequest(
@@ -1870,8 +1869,8 @@ func TestHandlers_PutRequest(t *testing.T) {
 				group).
 			Return(updateRequest, nil)
 
-		assert.NoError(t, h.Handlers.PutRequest(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutRequest(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *RequestDetailResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -1902,9 +1901,9 @@ func TestHandlers_PutRequest(t *testing.T) {
 		require.NoError(t, err)
 
 		err = h.Handlers.PutRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -1928,9 +1927,9 @@ func TestHandlers_PutRequest(t *testing.T) {
 		resErr := errors.New("invalid UUID")
 
 		err = h.Handlers.PutRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownID", func(t *testing.T) {
@@ -1978,9 +1977,9 @@ func TestHandlers_PutRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PutRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("UnknownTagID", func(t *testing.T) {
@@ -2046,9 +2045,9 @@ func TestHandlers_PutRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PutRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("UnknownGroupID", func(t *testing.T) {
@@ -2117,9 +2116,9 @@ func TestHandlers_PutRequest(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PutRequest(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 }
 
@@ -2197,9 +2196,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2225,8 +2224,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2317,9 +2316,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2345,8 +2344,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2437,9 +2436,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2465,8 +2464,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2557,9 +2556,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2585,8 +2584,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2677,9 +2676,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2705,8 +2704,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2804,9 +2803,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2836,8 +2835,8 @@ func TestHandlers_PutStatus(t *testing.T) {
 			CreateComment(ctx, reqStatus.Comment, request.ID, user.ID).
 			Return(comment, nil)
 
-		assert.NoError(t, h.Handlers.PutStatus(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutStatus(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *StatusResponse
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -2918,9 +2917,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2936,9 +2935,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		resErr.Message = resErrMessage
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい
-		assert.Equal(t, resErr, err)
+		require.Equal(t, resErr, err)
 	})
 
 	t.Run("InvalidUUID", func(t *testing.T) {
@@ -2981,9 +2980,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -2992,9 +2991,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		}
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NillUUID", func(t *testing.T) {
@@ -3035,9 +3034,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3048,9 +3047,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		_, resErr := uuid.Parse(c.Param("requestID"))
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("SessionNotFound", func(t *testing.T) {
@@ -3111,14 +3110,14 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resErr := errors.New("sessionUser not found")
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusForbiddenだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusForbidden, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusForbidden, resErr), err)
 	})
 
 	t.Run("SameStatusError", func(t *testing.T) {
@@ -3179,9 +3178,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3198,9 +3197,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		resErr := errors.New("invalid request: same status")
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("CommentRequiredErrorFromSubmittedToFixRequired", func(t *testing.T) {
@@ -3261,9 +3260,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3283,9 +3282,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			reqStatus.Status.String())
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("CommentRequiredErrorFromSubmittedToRejected", func(t *testing.T) {
@@ -3345,9 +3344,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3367,9 +3366,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			reqStatus.Status.String())
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("CommentRequiredErrorFromAcceptedToSubmitted", func(t *testing.T) {
@@ -3429,9 +3428,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3451,9 +3450,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			reqStatus.Status.String())
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("UnknownUser", func(t *testing.T) {
@@ -3514,9 +3513,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3538,9 +3537,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			Return(nil, resErr)
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusNotFoundだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusNotFound, resErr), err)
 	})
 
 	t.Run("AdminNoPrivilege", func(t *testing.T) {
@@ -3601,9 +3600,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3627,9 +3626,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			reqStatus.Status.String())
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusForbiddenだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("AlreadyPaid", func(t *testing.T) {
@@ -3697,9 +3696,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3724,9 +3723,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		resErr := errors.New("someone already paid")
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("CreatorNoPrivilege", func(t *testing.T) {
@@ -3787,9 +3786,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3812,9 +3811,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			request.Status.String(), reqStatus.Status.String())
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusForbiddenだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NoPrivilege", func(t *testing.T) {
@@ -3875,9 +3874,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 		require.NoError(t, err)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess, err := session.Get(h.Handlers.SessionName, c)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		sess.Values[sessionUserKey] = User{
 			ID:          user.ID,
 			Name:        user.Name,
@@ -3896,9 +3895,9 @@ func TestHandlers_PutStatus(t *testing.T) {
 			Return(user, nil)
 
 		err = h.Handlers.PutStatus(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusForbiddenだけ判定したい
-		assert.Equal(t, echo.NewHTTPError(http.StatusForbidden), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusForbidden), err)
 	})
 }
 

--- a/router/tag_test.go
+++ b/router/tag_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/model"
 	"github.com/traPtitech/Jomon/testutil"
@@ -51,14 +50,14 @@ func TestHandlers_GetTags(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockTagRepository.
 			EXPECT().
 			GetTags(c.Request().Context()).
 			Return(tags, nil)
 
-		assert.NoError(t, h.Handlers.GetTags(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTags(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*TagOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -88,14 +87,14 @@ func TestHandlers_GetTags(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockTagRepository.
 			EXPECT().
 			GetTags(c.Request().Context()).
 			Return(tags, nil)
 
-		assert.NoError(t, h.Handlers.GetTags(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTags(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*TagOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -116,7 +115,7 @@ func TestHandlers_GetTags(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		mocErr := errors.New("failed to get tags")
 		h.Repository.MockTagRepository.
 			EXPECT().
@@ -124,9 +123,9 @@ func TestHandlers_GetTags(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetTags(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 }
 
@@ -159,15 +158,15 @@ func TestHandlers_PostTag(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		h.Repository.MockTagRepository.
 			EXPECT().
 			CreateTag(c.Request().Context(), tag.Name).
 			Return(tag, nil)
 
-		assert.NoError(t, h.Handlers.PostTag(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostTag(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got TagOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -207,7 +206,7 @@ func TestHandlers_PostTag(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mocErr := errors.New("Tag name can't be empty.")
 		h.Repository.MockTagRepository.
@@ -216,9 +215,9 @@ func TestHandlers_PostTag(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.PostTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 }
 
@@ -261,15 +260,15 @@ func TestHandlers_PutTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		h.Repository.MockTagRepository.
 			EXPECT().
 			UpdateTag(c.Request().Context(), tag.ID, reqTag.Name).
 			Return(updateTag, nil)
 
-		assert.NoError(t, h.Handlers.PutTag(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutTag(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got TagOverview
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -312,7 +311,7 @@ func TestHandlers_PutTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mocErr := errors.New("Tag name can't be empty.")
 		h.Repository.MockTagRepository.
@@ -321,9 +320,9 @@ func TestHandlers_PutTag(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.PutTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("InvalidUUID", func(t *testing.T) {
@@ -359,12 +358,12 @@ func TestHandlers_PutTag(t *testing.T) {
 		c.SetParamValues(invalidUUID)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = h.Handlers.PutTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -397,13 +396,13 @@ func TestHandlers_PutTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resErr := errors.New("invalid tag ID")
 		err = h.Handlers.PutTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }
 
@@ -441,15 +440,15 @@ func TestHandlers_DeleteTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		h.Repository.MockTagRepository.
 			EXPECT().
 			DeleteTag(c.Request().Context(), tag.ID).
 			Return(nil)
 
-		assert.NoError(t, h.Handlers.DeleteTag(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.DeleteTag(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 	})
 
 	t.Run("UnknownID", func(t *testing.T) {
@@ -483,7 +482,7 @@ func TestHandlers_DeleteTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		mocErr := errors.New("Unknown Tag ID")
 		h.Repository.MockTagRepository.
@@ -492,9 +491,9 @@ func TestHandlers_DeleteTag(t *testing.T) {
 			Return(mocErr)
 
 		err = h.Handlers.DeleteTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("InvalidUUID", func(t *testing.T) {
@@ -531,12 +530,12 @@ func TestHandlers_DeleteTag(t *testing.T) {
 		c.SetParamValues(invalidUUID)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		err = h.Handlers.DeleteTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 
 	t.Run("NilUUID", func(t *testing.T) {
@@ -570,12 +569,12 @@ func TestHandlers_DeleteTag(t *testing.T) {
 		c.SetParamValues(tag.ID.String())
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resErr := errors.New("invalid tag ID")
 		err = h.Handlers.DeleteTag(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, resErr), err)
 	})
 }

--- a/router/transaction_test.go
+++ b/router/transaction_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/model"
 	"github.com/traPtitech/Jomon/service"
@@ -130,8 +129,8 @@ func TestHandlers_GetTransactions(t *testing.T) {
 			}).
 			Return(txs, nil)
 
-		assert.NoError(t, h.Handlers.GetTransactions(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransactions(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -216,8 +215,8 @@ func TestHandlers_GetTransactions(t *testing.T) {
 			}).
 			Return(txs, nil)
 
-		assert.NoError(t, h.Handlers.GetTransactions(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransactions(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -303,8 +302,8 @@ func TestHandlers_GetTransactions(t *testing.T) {
 			}).
 			Return(txs, nil)
 
-		assert.NoError(t, h.Handlers.GetTransactions(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransactions(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -390,8 +389,8 @@ func TestHandlers_GetTransactions(t *testing.T) {
 			}).
 			Return(txs, nil)
 
-		assert.NoError(t, h.Handlers.GetTransactions(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransactions(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -460,8 +459,8 @@ func TestHandlers_GetTransactions(t *testing.T) {
 			}).
 			Return(txs, nil)
 
-		assert.NoError(t, h.Handlers.GetTransactions(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransactions(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -546,8 +545,8 @@ func TestHandlers_PostTransaction(t *testing.T) {
 				tx1.Title, tx1.Amount, tx1.Target, tags, &group, nil).
 			Return(tx1, nil)
 
-		assert.NoError(t, h.Handlers.PostTransaction(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostTransaction(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -635,8 +634,8 @@ func TestHandlers_PostTransaction(t *testing.T) {
 				tags, &group, &request.ID).
 			Return(tx, nil)
 
-		assert.NoError(t, h.Handlers.PostTransaction(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PostTransaction(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -705,8 +704,8 @@ func TestHandlers_GetTransaction(t *testing.T) {
 			GetTransaction(c.Request().Context(), tx.ID).
 			Return(tx, nil)
 
-		assert.NoError(t, h.Handlers.GetTransaction(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetTransaction(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)
@@ -810,8 +809,8 @@ func TestHandlers_PutTransaction(t *testing.T) {
 				tx.ID, updated.Title, updated.Amount, updated.Target,
 				updatedTags, nil, nil).
 			Return(updated, nil)
-		assert.NoError(t, h.Handlers.PutTransaction(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.PutTransaction(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got *Transaction
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
 		require.NoError(t, err)

--- a/router/user_test.go
+++ b/router/user_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labstack/echo-contrib/session"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/Jomon/model"
 	"github.com/traPtitech/Jomon/testutil"
@@ -53,17 +52,17 @@ func TestHandlers_GetUsers(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockUserRepository.
 			EXPECT().
 			GetUsers(c.Request().Context()).
 			Return(users, nil)
 
-		assert.NoError(t, h.Handlers.GetUsers(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetUsers(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*User
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := lo.Map(users, func(u *model.User, _ int) *User {
 			return modelUserToUser(u)
@@ -85,17 +84,17 @@ func TestHandlers_GetUsers(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		h.Repository.MockUserRepository.
 			EXPECT().
 			GetUsers(c.Request().Context()).
 			Return(users, nil)
 
-		assert.NoError(t, h.Handlers.GetUsers(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetUsers(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got []*User
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := lo.Map(users, func(u *model.User, _ int) *User {
 			return modelUserToUser(u)
@@ -124,9 +123,9 @@ func TestHandlers_GetUsers(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetUsers(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 }
 
@@ -154,7 +153,7 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 			Admin:       updateUser.Admin,
 		}
 		reqBody, err := json.Marshal(reqUser)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		e := echo.New()
 		req := httptest.NewRequestWithContext(
@@ -164,7 +163,7 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 		c := e.NewContext(req, rec)
 
 		h, err := NewTestHandlers(t, ctrl)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		h.Repository.MockUserRepository.
 			EXPECT().
@@ -177,11 +176,11 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 				user.ID, updateUser.Name, updateUser.DisplayName, updateUser.Admin).
 			Return(updateUser, nil)
 
-		assert.NoError(t, h.Handlers.UpdateUserInfo(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.UpdateUserInfo(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got User
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		// FIXME: #835
 		opts = append(opts,
@@ -210,7 +209,7 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 			Admin:       updateUser.Admin,
 		}
 		bodyReqUser, err := json.Marshal(reqUser)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		e := echo.New()
 		req := httptest.NewRequestWithContext(
@@ -234,9 +233,9 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.UpdateUserInfo(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, mocErr), err)
 	})
 
 	t.Run("FailedToGetUser", func(t *testing.T) {
@@ -259,7 +258,7 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 			Admin:       updateUser.Admin,
 		}
 		bodyReqUser, err := json.Marshal(reqUser)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		e := echo.New()
 		req := httptest.NewRequestWithContext(
@@ -277,9 +276,9 @@ func TestHandlers_UpdateUserInfo(t *testing.T) {
 			Return(nil, mocErr)
 
 		err = h.Handlers.UpdateUserInfo(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusBadRequestだけ判定したい; mocErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusBadRequest, mocErr), err)
 	})
 }
 
@@ -318,11 +317,11 @@ func TestHandlers_GetMe(t *testing.T) {
 			GetUserByID(c.Request().Context(), user.ID).
 			Return(accessUser, nil)
 
-		assert.NoError(t, h.Handlers.GetMe(c))
-		assert.Equal(t, http.StatusOK, rec.Code)
+		require.NoError(t, h.Handlers.GetMe(c))
+		require.Equal(t, http.StatusOK, rec.Code)
 		var got User
 		err = json.Unmarshal(rec.Body.Bytes(), &got)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		opts := testutil.ApproxEqualOptions()
 		exp := modelUserToUser(accessUser)
 		testutil.RequireEqual(t, exp, &got, opts...)
@@ -351,8 +350,8 @@ func TestHandlers_GetMe(t *testing.T) {
 
 		resErr := "failed to get user info"
 		err = h.Handlers.GetMe(c)
-		assert.Error(t, err)
+		require.Error(t, err)
 		// FIXME: http.StatusInternalServerErrorだけ判定したい; resErrの内容は関係ない
-		assert.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
+		require.Equal(t, echo.NewHTTPError(http.StatusInternalServerError, resErr), err)
 	})
 }


### PR DESCRIPTION
#821

ひとまず`router/admin_test.go`の中身のみ変更
基本`assert`を`require`に変更していったがHTTPステータスと`resBody`の比較する部分はエラー時に両方見れた方がいいと思ったので`assert`のままにした
`resuire`に変更する中で不要な`if`文を消した