### PR TITLE
add contect.Context to Storage interface method argument

### DIFF
--- a/router/file.go
+++ b/router/file.go
@@ -93,7 +93,7 @@ func (h Handlers) PostFile(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	err = h.Storage.Save(file.ID.String(), src)
+	err = h.Storage.Save(ctx, file.ID.String(), src)
 	if err != nil {
 		logger.Error("failed to save file id in storage", zap.Error(err))
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
@@ -140,7 +140,7 @@ func (h Handlers) GetFile(c echo.Context) error {
 		}
 	}
 
-	f, err := h.Storage.Open(fileID.String())
+	f, err := h.Storage.Open(ctx, fileID.String())
 	if err != nil {
 		logger.Error(
 			"failed to open file in storage",
@@ -209,7 +209,7 @@ func (h Handlers) DeleteFile(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	err = h.Storage.Delete(fileID.String())
+	err = h.Storage.Delete(ctx, fileID.String())
 	if err != nil {
 		logger.Error("failed to delete file in storage", zap.Error(err))
 		return echo.NewHTTPError(http.StatusInternalServerError, err)

--- a/router/file_test.go
+++ b/router/file_test.go
@@ -84,7 +84,7 @@ func TestHandlers_PostFile(t *testing.T) {
 
 		h.Storage.
 			EXPECT().
-			Save(file.ID.String(), gomock.Any()).
+			Save(c.Request().Context(), file.ID.String(), gomock.Any()).
 			Return(nil)
 
 		require.NoError(t, h.Handlers.PostFile(c))
@@ -204,7 +204,7 @@ func TestHandlers_PostFile(t *testing.T) {
 
 		h.Storage.
 			EXPECT().
-			Save(file.ID.String(), gomock.Any()).
+			Save(c.Request().Context(), file.ID.String(), gomock.Any()).
 			Return(mocErr)
 
 		err = h.Handlers.PostFile(c)
@@ -252,7 +252,7 @@ func TestHandlers_GetFile(t *testing.T) {
 
 		h.Storage.
 			EXPECT().
-			Open(file.ID.String()).
+			Open(c.Request().Context(), file.ID.String()).
 			Return(r, nil)
 
 		require.NoError(t, h.Handlers.GetFile(c))
@@ -329,7 +329,7 @@ func TestHandlers_GetFile(t *testing.T) {
 
 		h.Storage.
 			EXPECT().
-			Open(file.ID.String()).
+			Open(c.Request().Context(), file.ID.String()).
 			Return(nil, mocErr)
 
 		err = h.Handlers.GetFile(c)
@@ -517,7 +517,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 			Return(nil)
 		h.Storage.
 			EXPECT().
-			Delete(file.ID.String()).
+			Delete(c.Request().Context(), file.ID.String()).
 			Return(nil)
 
 		require.NoError(t, h.Handlers.DeleteFile(c))
@@ -610,7 +610,7 @@ func TestHandlers_DeleteFile(t *testing.T) {
 
 		h.Storage.
 			EXPECT().
-			Delete(file.ID.String()).
+			Delete(c.Request().Context(), file.ID.String()).
 			Return(mocErr)
 
 		err = h.Handlers.DeleteFile(c)

--- a/storage/local.go
+++ b/storage/local.go
@@ -12,8 +12,6 @@ type Local struct {
 	localDir string
 }
 
-var _ Storage = (*Local)(nil)
-
 func NewLocalStorage(dir string) (*Local, error) {
 	fi, err := os.Stat(dir)
 	if err != nil {
@@ -56,3 +54,5 @@ func (l *Local) Delete(ctx context.Context, filename string) error {
 func (l *Local) getFilePath(filename string) string {
 	return filepath.Join(l.localDir, filename)
 }
+
+var _ Storage = (*Local)(nil)

--- a/storage/local.go
+++ b/storage/local.go
@@ -24,7 +24,7 @@ func NewLocalStorage(dir string) (*Local, error) {
 	return &Local{localDir: dir}, nil
 }
 
-func (l *Local) Save(ctx context.Context, filename string, src io.Reader) error {
+func (l *Local) Save(_ context.Context, filename string, src io.Reader) error {
 	file, err := os.Create(l.getFilePath(filename))
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (l *Local) Save(ctx context.Context, filename string, src io.Reader) error 
 	return err
 }
 
-func (l *Local) Open(ctx context.Context, filename string) (io.ReadCloser, error) {
+func (l *Local) Open(_ context.Context, filename string) (io.ReadCloser, error) {
 	r, err := os.Open(l.getFilePath(filename))
 	if err != nil {
 		return nil, ErrFileNotFound
@@ -43,7 +43,7 @@ func (l *Local) Open(ctx context.Context, filename string) (io.ReadCloser, error
 	return r, nil
 }
 
-func (l *Local) Delete(ctx context.Context, filename string) error {
+func (l *Local) Delete(_ context.Context, filename string) error {
 	path := l.getFilePath(filename)
 	if _, err := os.Stat(path); err != nil {
 		return ErrFileNotFound

--- a/storage/local.go
+++ b/storage/local.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -10,6 +11,8 @@ import (
 type Local struct {
 	localDir string
 }
+
+var _ Storage = (*Local)(nil)
 
 func NewLocalStorage(dir string) (*Local, error) {
 	fi, err := os.Stat(dir)
@@ -23,7 +26,7 @@ func NewLocalStorage(dir string) (*Local, error) {
 	return &Local{localDir: dir}, nil
 }
 
-func (l *Local) Save(filename string, src io.Reader) error {
+func (l *Local) Save(ctx context.Context, filename string, src io.Reader) error {
 	file, err := os.Create(l.getFilePath(filename))
 	if err != nil {
 		return err
@@ -34,7 +37,7 @@ func (l *Local) Save(filename string, src io.Reader) error {
 	return err
 }
 
-func (l *Local) Open(filename string) (io.ReadCloser, error) {
+func (l *Local) Open(ctx context.Context, filename string) (io.ReadCloser, error) {
 	r, err := os.Open(l.getFilePath(filename))
 	if err != nil {
 		return nil, ErrFileNotFound
@@ -42,7 +45,7 @@ func (l *Local) Open(filename string) (io.ReadCloser, error) {
 	return r, nil
 }
 
-func (l *Local) Delete(filename string) error {
+func (l *Local) Delete(ctx context.Context, filename string) error {
 	path := l.getFilePath(filename)
 	if _, err := os.Stat(path); err != nil {
 		return ErrFileNotFound

--- a/storage/mock_storage/mock_storage.go
+++ b/storage/mock_storage/mock_storage.go
@@ -10,6 +10,7 @@
 package mock_storage
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -20,6 +21,7 @@ import (
 type MockStorage struct {
 	ctrl     *gomock.Controller
 	recorder *MockStorageMockRecorder
+	isgomock struct{}
 }
 
 // MockStorageMockRecorder is the mock recorder for MockStorage.
@@ -40,44 +42,44 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockStorage) Delete(filename string) error {
+func (m *MockStorage) Delete(ctx context.Context, filename string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", filename)
+	ret := m.ctrl.Call(m, "Delete", ctx, filename)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockStorageMockRecorder) Delete(filename any) *gomock.Call {
+func (mr *MockStorageMockRecorder) Delete(ctx, filename any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStorage)(nil).Delete), filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStorage)(nil).Delete), ctx, filename)
 }
 
 // Open mocks base method.
-func (m *MockStorage) Open(filename string) (io.ReadCloser, error) {
+func (m *MockStorage) Open(ctx context.Context, filename string) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", filename)
+	ret := m.ctrl.Call(m, "Open", ctx, filename)
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockStorageMockRecorder) Open(filename any) *gomock.Call {
+func (mr *MockStorageMockRecorder) Open(ctx, filename any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockStorage)(nil).Open), filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockStorage)(nil).Open), ctx, filename)
 }
 
 // Save mocks base method.
-func (m *MockStorage) Save(filename string, src io.Reader) error {
+func (m *MockStorage) Save(ctx context.Context, filename string, src io.Reader) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Save", filename, src)
+	ret := m.ctrl.Call(m, "Save", ctx, filename, src)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Save indicates an expected call of Save.
-func (mr *MockStorageMockRecorder) Save(filename, src any) *gomock.Call {
+func (mr *MockStorageMockRecorder) Save(ctx, filename, src any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockStorage)(nil).Save), filename, src)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockStorage)(nil).Save), ctx, filename, src)
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -17,8 +17,6 @@ type S3Storage struct {
 	client *s3.Client
 }
 
-var _ Storage = (*S3Storage)(nil)
-
 func NewS3Storage(cfg aws.Config, bucket string) *S3Storage {
 	client := s3.NewFromConfig(cfg)
 
@@ -78,3 +76,5 @@ func (fs *S3Storage) Delete(ctx context.Context, key string) error {
 	}
 	return nil
 }
+
+var _ Storage = (*S3Storage)(nil)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,6 +2,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"io"
 )
@@ -11,7 +12,7 @@ var (
 )
 
 type Storage interface {
-	Save(filename string, src io.Reader) error
-	Open(filename string) (io.ReadCloser, error)
-	Delete(filename string) error
+	Save(ctx context.Context, filename string, src io.Reader) error
+	Open(ctx context.Context, filename string) (io.ReadCloser, error)
+	Delete(ctx context.Context, filename string) error
 }

--- a/storage/swift.go
+++ b/storage/swift.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -11,6 +12,8 @@ type Swift struct {
 	container string
 	conn      *swift.Connection
 }
+
+var _ Storage = (*Swift)(nil)
 
 func NewSwiftStorage(
 	container string, userName string, apiKey string,
@@ -39,12 +42,12 @@ func NewSwiftStorage(
 	return s, nil
 }
 
-func (s *Swift) Save(filename string, src io.Reader) error {
+func (s *Swift) Save(ctx context.Context, filename string, src io.Reader) error {
 	_, err := s.conn.ObjectPut(s.container, filename, src, true, "", "", swift.Headers{})
 	return err
 }
 
-func (s *Swift) Open(filename string) (io.ReadCloser, error) {
+func (s *Swift) Open(ctx context.Context, filename string) (io.ReadCloser, error) {
 	file, _, err := s.conn.ObjectOpen(s.container, filename, true, nil)
 	if err != nil {
 		if errors.Is(err, swift.ObjectNotFound) {
@@ -55,7 +58,7 @@ func (s *Swift) Open(filename string) (io.ReadCloser, error) {
 	return file, nil
 }
 
-func (s *Swift) Delete(filename string) error {
+func (s *Swift) Delete(ctx context.Context, filename string) error {
 	err := s.conn.ObjectDelete(s.container, filename)
 	if err != nil {
 		if errors.Is(err, swift.ObjectNotFound) {

--- a/storage/swift.go
+++ b/storage/swift.go
@@ -40,12 +40,12 @@ func NewSwiftStorage(
 	return s, nil
 }
 
-func (s *Swift) Save(ctx context.Context, filename string, src io.Reader) error {
+func (s *Swift) Save(_ context.Context, filename string, src io.Reader) error {
 	_, err := s.conn.ObjectPut(s.container, filename, src, true, "", "", swift.Headers{})
 	return err
 }
 
-func (s *Swift) Open(ctx context.Context, filename string) (io.ReadCloser, error) {
+func (s *Swift) Open(_ context.Context, filename string) (io.ReadCloser, error) {
 	file, _, err := s.conn.ObjectOpen(s.container, filename, true, nil)
 	if err != nil {
 		if errors.Is(err, swift.ObjectNotFound) {
@@ -56,7 +56,7 @@ func (s *Swift) Open(ctx context.Context, filename string) (io.ReadCloser, error
 	return file, nil
 }
 
-func (s *Swift) Delete(ctx context.Context, filename string) error {
+func (s *Swift) Delete(_ context.Context, filename string) error {
 	err := s.conn.ObjectDelete(s.container, filename)
 	if err != nil {
 		if errors.Is(err, swift.ObjectNotFound) {

--- a/storage/swift.go
+++ b/storage/swift.go
@@ -13,8 +13,6 @@ type Swift struct {
 	conn      *swift.Connection
 }
 
-var _ Storage = (*Swift)(nil)
-
 func NewSwiftStorage(
 	container string, userName string, apiKey string,
 	tenant string, tenantID string, authURL string,
@@ -68,3 +66,5 @@ func (s *Swift) Delete(ctx context.Context, filename string) error {
 	}
 	return nil
 }
+
+var _ Storage = (*Swift)(nil)


### PR DESCRIPTION
#907
`Storage`interfaceに`context.Context`を追加
`./storage`のmock更新
`Swift`と`Local`に[おまじない](https://zenn.dev/seri_k/articles/df3052543f1c62)追加