### PR TITLE
docs(swagger): ` PUT /applications/{applicationID}`のリクエストボディの`target`に`paid_at`を追加

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,7 +74,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationPostInput"
+              $ref: "#/components/schemas/PostApplicationInput"
       responses:
         "201":
           description: 作成できた場合。作成された申請の詳細を返す。
@@ -117,7 +117,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationPutInput"
+              $ref: "#/components/schemas/PutApplicationInput"
       responses:
         "200":
           description: 修正できた場合。修正後の詳細を返す。
@@ -1025,7 +1025,7 @@ components:
         - targets
         - created_at
         - updated_at
-    ApplicationPostInput:
+    PostApplicationInput:
       type: object
       properties:
         created_by:
@@ -1055,7 +1055,7 @@ components:
         - tags
         - partition
         - targets
-    ApplicationPutInput:
+    PutApplicationInput:
       type: object
       properties:
         created_by:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -869,7 +869,7 @@ components:
         - name
         - mime_type
         - created_at
-    ApplicationTargetPostInput:
+    PostApplicationTargetInput:
       type: object
       properties:
         amount:
@@ -881,7 +881,7 @@ components:
       required:
         - amount
         - target
-    ApplicationTargetPutInput:
+    PutApplicationTargetInput:
       type: object
       properties:
         amount:
@@ -1047,7 +1047,7 @@ components:
         targets:
           type: array
           items:
-            $ref: "#/components/schemas/ApplicationTargetPostInput"
+            $ref: "#/components/schemas/PostApplicationTargetInput"
       required:
         - title
         - content
@@ -1077,7 +1077,7 @@ components:
         targets:
           type: array
           items:
-            $ref: "#/components/schemas/ApplicationTargetPutInput"
+            $ref: "#/components/schemas/PutApplicationTargetInput"
       required:
         - title
         - content

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,7 +74,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationInput"
+              $ref: "#/components/schemas/ApplicationPostInput"
       responses:
         "201":
           description: 作成できた場合。作成された申請の詳細を返す。
@@ -117,7 +117,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApplicationInput"
+              $ref: "#/components/schemas/ApplicationPutInput"
       responses:
         "200":
           description: 修正できた場合。修正後の詳細を返す。
@@ -869,7 +869,7 @@ components:
         - name
         - mime_type
         - created_at
-    ApplicationTargetInput:
+    ApplicationTargetPostInput:
       type: object
       properties:
         amount:
@@ -881,6 +881,23 @@ components:
       required:
         - amount
         - target
+    ApplicationTargetPutInput:
+      type: object
+      properties:
+        amount:
+          type: integer
+          example: 1200
+        target:
+          type: string
+          format: uuid
+        paid_at:
+          type: string
+          nullable: true
+          format: date-time
+      required:
+        - amount
+        - target
+        - paid_at
     ApplicationTarget:
       type: object
       properties:
@@ -1008,7 +1025,7 @@ components:
         - targets
         - created_at
         - updated_at
-    ApplicationInput:
+    ApplicationPostInput:
       type: object
       properties:
         created_by:
@@ -1030,7 +1047,37 @@ components:
         targets:
           type: array
           items:
-            $ref: "#/components/schemas/ApplicationTargetInput"
+            $ref: "#/components/schemas/ApplicationTargetPostInput"
+      required:
+        - title
+        - content
+        - created_by
+        - tags
+        - partition
+        - targets
+    ApplicationPutInput:
+      type: object
+      properties:
+        created_by:
+          $ref: "#/components/schemas/UserID"
+        title:
+          type: string
+          example: "SysAd講習会の開催費用"
+        content:
+          type: string
+          example: "サーバー代 1200円"
+        tags:
+          type: array
+          items:
+            type: string
+            format: uuid
+        partition:
+          type: string
+          format: uuid
+        targets:
+          type: array
+          items:
+            $ref: "#/components/schemas/ApplicationTargetPutInput"
       required:
         - title
         - content


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * アプリケーション作成（POST）と更新（PUT）で別々のリクエスト検証スキーマを導入しました
  * POST と PUT で適用されるスキーマが分離されるようになりました
  * 更新（PUT）操作のアプリケーションターゲットに新しい日時フィールド（nullable）が必須として追加されました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->