### PR TITLE
fix: service以下の状態名変更

### DIFF
--- a/internal/service/application.go
+++ b/internal/service/application.go
@@ -219,7 +219,7 @@ func (s *Service) UpdateApplicationStatus(
 			application.Status.String(), inputs.Status.String())
 		return nil, nil, NewBadInputError(message)
 	}
-	if s.isAccountManagerRevertingAcceptedApplication(user, application.Status, inputs.Status) {
+	if s.isAccountManagerRevertingApprovedApplication(user, application.Status, inputs.Status) {
 		targets, err := s.repository.GetApplicationTargets(ctx, applicationID)
 		if err != nil {
 			logger.Error("failed to get application targets from repository", zap.Error(err))
@@ -262,11 +262,11 @@ func (s *Service) isAccountManager(user *User) bool {
 
 func (s *Service) isAbleNoCommentUpdateStatus(currentStatus, newStatus Status) bool {
 	switch currentStatus {
-	case Submitted:
-		return newStatus != FixRequired && newStatus != Rejected
-	case Accepted:
-		return newStatus != Submitted
-	case FixRequired, Completed, Rejected:
+	case PendingReview:
+		return newStatus != ChangeRequested && newStatus != Rejected
+	case Approved:
+		return newStatus != PendingReview
+	case ChangeRequested, PaymentFinished, Rejected:
 		return true
 	default:
 		return false
@@ -274,19 +274,19 @@ func (s *Service) isAbleNoCommentUpdateStatus(currentStatus, newStatus Status) b
 }
 
 func (s *Service) isAbleAccountManagerUpdateStatus(currentStatus, newStatus Status) bool {
-	return newStatus == Rejected && currentStatus == Submitted ||
-		newStatus == Submitted && currentStatus == FixRequired ||
-		newStatus == Accepted && currentStatus == Submitted ||
-		newStatus == Submitted && currentStatus == Accepted ||
-		newStatus == FixRequired && currentStatus == Submitted
+	return newStatus == Rejected && currentStatus == PendingReview ||
+		newStatus == PendingReview && currentStatus == ChangeRequested ||
+		newStatus == Approved && currentStatus == PendingReview ||
+		newStatus == PendingReview && currentStatus == Approved ||
+		newStatus == ChangeRequested && currentStatus == PendingReview
 }
 
 func (s *Service) isAbleCreatorChangeStatus(currentStatus, newStatus Status) bool {
-	return currentStatus == FixRequired && newStatus == Submitted
+	return currentStatus == ChangeRequested && newStatus == PendingReview
 }
 
-func (s *Service) isAccountManagerRevertingAcceptedApplication(
+func (s *Service) isAccountManagerRevertingApprovedApplication(
 	user *User, currentStatus, newStatus Status,
 ) bool {
-	return user.AccountManager && currentStatus == Accepted && newStatus == Submitted
+	return user.AccountManager && currentStatus == Approved && newStatus == PendingReview
 }

--- a/internal/service/application_status.go
+++ b/internal/service/application_status.go
@@ -14,23 +14,23 @@ type Status int
 
 const (
 	_ Status = iota
-	Submitted
-	FixRequired
-	Accepted
-	Completed
+	PendingReview
+	ChangeRequested
+	Approved
+	PaymentFinished
 	Rejected
 )
 
 func (s Status) String() string {
 	switch s {
-	case Submitted:
-		return "submitted"
-	case FixRequired:
-		return "fix_required"
-	case Accepted:
-		return "accepted"
-	case Completed:
-		return "completed"
+	case PendingReview:
+		return "pending_review"
+	case ChangeRequested:
+		return "change_requested"
+	case Approved:
+		return "approved"
+	case PaymentFinished:
+		return "payment_finished"
 	case Rejected:
 		return "rejected"
 	default:
@@ -42,14 +42,14 @@ func (s Status) String() string {
 // dbにstringいれる今の実装だとMarshalJson入らなそう。
 func (s Status) MarshalJSON() ([]byte, error) {
 	switch s {
-	case Submitted:
-		return json.Marshal("submitted")
-	case FixRequired:
-		return json.Marshal("fix_required")
-	case Accepted:
-		return json.Marshal("accepted")
-	case Completed:
-		return json.Marshal("completed")
+	case PendingReview:
+		return json.Marshal("pending_review")
+	case ChangeRequested:
+		return json.Marshal("change_requested")
+	case Approved:
+		return json.Marshal("approved")
+	case PaymentFinished:
+		return json.Marshal("payment_finished")
 	case Rejected:
 		return json.Marshal("rejected")
 	default:
@@ -65,14 +65,14 @@ func (s *Status) UnmarshalJSON(data []byte) error {
 
 	var st Status
 	switch str {
-	case "submitted":
-		st = Submitted
-	case "fix_required":
-		st = FixRequired
-	case "accepted":
-		st = Accepted
-	case "completed":
-		st = Completed
+	case "pending_review":
+		st = PendingReview
+	case "change_requested":
+		st = ChangeRequested
+	case "approved":
+		st = Approved
+	case "payment_finished":
+		st = PaymentFinished
 	case "rejected":
 		st = Rejected
 	default:

--- a/internal/service/file.go
+++ b/internal/service/file.go
@@ -31,7 +31,7 @@ type File struct {
 	CreatedAt time.Time
 }
 
-var acceptedMimeTypes = map[string]bool{
+var ApprovedMimeTypes = map[string]bool{
 	"image/jpeg":         true,
 	"image/png":          true,
 	"image/gif":          true,
@@ -98,7 +98,7 @@ func (s *Service) WriteFile(
 	user *User, applicationID uuid.UUID,
 	name string, mimetype string, content io.Reader,
 ) (*File, error) {
-	if !acceptedMimeTypes[mimetype] {
+	if !ApprovedMimeTypes[mimetype] {
 		return nil, NewBadInputError("unsupported mime type")
 	}
 	logger := logging.GetLogger(ctx)


### PR DESCRIPTION
#904

servise内の状態名のみ変更
現状行ったのは状態名の変更のみ

状態遷移の修正に関して、現状の遷移図がわからない・現状のプログラムの意図が読むだけではわかりにくかったためまだ行っていないが、状態遷移を行っている場所は見つけた

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * アカウントマネージャーが承認済みのアプリケーションを再確認待ちの状態に戻す機能を追加しました。

* **Refactor**
  * アプリケーションステータスの管理ロジックとバリデーション条件を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->